### PR TITLE
Improve DHCP hook reliability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/transparency-dev/armored-witness-applet
 go 1.19
 
 require (
-	github.com/miekg/dns v1.1.54
 	github.com/golang/glog v1.1.1
+	github.com/miekg/dns v1.1.54
 	github.com/transparency-dev/armored-witness-os v0.0.0-20230504100200-51ba0628e5ed
 	github.com/usbarmory/GoTEE v0.0.0-20230127101228-519e560d69aa
 	github.com/usbarmory/imx-enet v0.0.0-20230210123530-18463adc40b7

--- a/trusted_applet/main.go
+++ b/trusted_applet/main.go
@@ -128,9 +128,14 @@ func runWithNetworking(ctx context.Context) error {
 
 	listener, err := iface.ListenerTCP4(22)
 	if err != nil {
-		log.Fatalf("TA could not initialize SSH listener, %v", err)
+		return fmt.Errorf("TA could not initialize SSH listener, %v", err)
 	}
-	defer listener.Close()
+	defer func() {
+		log.Println("Closing ssh port")
+		if err := listener.Close(); err != nil {
+			log.Printf("Error closing ssh port: %v", err)
+		}
+	}()
 
 	go startSSHServer(ctx, listener, addr.Address.String(), 22, cmd.Console)
 

--- a/trusted_applet/net.go
+++ b/trusted_applet/net.go
@@ -101,7 +101,7 @@ func runDHCP(ctx context.Context, nicID tcpip.NICID, f func(context.Context) err
 		log.Printf("DHCPC: lease update - old: %v, new: %v", oldAddr.String(), newAddr.String())
 		// Handled renewals first, old and new addresses will be equivalent in this case.
 		// We may still have to reconfigure the networking stack, even though our assigned IP
-		// isn't changing, as the DHCP server could have changed routing or DNS info.
+		// isn't changing, the DHCP server could have changed routing or DNS info.
 		if oldAddr.Address == newAddr.Address && oldAddr.PrefixLen == newAddr.PrefixLen {
 			log.Printf("DHCPC: existing lease on %v renewed", newAddr.String())
 			// reconfigure network stuff in-case DNS or gateway routes have changed.

--- a/trusted_applet/ssh.go
+++ b/trusted_applet/ssh.go
@@ -132,9 +132,9 @@ func startSSHServer(ctx context.Context, listener net.Listener, addr string, por
 
 	srv.AddHostKey(signer)
 
-	chansToClose := []*ssh.ServerConn{}
+	connsToClose := []*ssh.ServerConn{}
 	defer func() {
-		for _, sc := range chansToClose {
+		for _, sc := range connsToClose {
 			log.Printf("Closing SSH connection from %s", sc.RemoteAddr())
 			sc.Close()
 		}
@@ -160,7 +160,7 @@ func startSSHServer(ctx context.Context, listener net.Listener, addr string, por
 			log.Printf("error accepting handshake, %v", err)
 			continue
 		}
-		chansToClose = append(chansToClose, sshConn)
+		connsToClose = append(connsToClose, sshConn)
 
 		log.Printf("new ssh connection from %s (%s)", sshConn.RemoteAddr(), sshConn.ClientVersion())
 

--- a/trusted_applet/ssh.go
+++ b/trusted_applet/ssh.go
@@ -132,6 +132,14 @@ func startSSHServer(ctx context.Context, listener net.Listener, addr string, por
 
 	srv.AddHostKey(signer)
 
+	chansToClose := []*ssh.ServerConn{}
+	defer func() {
+		for _, sc := range chansToClose {
+			log.Printf("Closing SSH connection from %s", sc.RemoteAddr())
+			sc.Close()
+		}
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -152,6 +160,7 @@ func startSSHServer(ctx context.Context, listener net.Listener, addr string, por
 			log.Printf("error accepting handshake, %v", err)
 			continue
 		}
+		chansToClose = append(chansToClose, sshConn)
 
 		log.Printf("new ssh connection from %s (%s)", sshConn.RemoteAddr(), sshConn.ClientVersion())
 


### PR DESCRIPTION
- Ensure we tell the user-provided function to exit, and wait for it to do so before ripping out old network config.
- Make SSH server close connections when network config changes.
- Factor out network configuration bits for better readability.