### PR TITLE
Add simple PR CI action

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,0 +1,25 @@
+name: PR CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    env:
+      TAMAGO_VERSION: 1.20.4
+      TAMAGO: /usr/local/tamago-go/bin/go
+      APPLET_PRIVATE_KEY: /tmp/applet.sec
+      APPLET_PUBLIC_KEY: /tmp/applet.pub
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install tools
+      run: |
+        wget -q https://github.com/usbarmory/tamago-go/releases/download/tamago-go${TAMAGO_VERSION}/tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz
+        sudo tar -xf tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz -C /
+        sudo apt install protobuf-compiler protoc-gen-go signify-openbsd
+    - name: Create throwaway keys
+      run: |
+        signify-openbsd -G -n -p ${APPLET_PUBLIC_KEY} -s ${APPLET_PRIVATE_KEY}
+    - name: Make
+      run: |
+        DEBUG=1 make trusted_applet


### PR DESCRIPTION
Currently this only attempts to set up a build env and make the `trusted_applet` target.