### PR TITLE
support BEE relocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,12 @@ SIGN = $(shell type -p signify || type -p signify-openbsd || type -p minisign)
 SIGN_PWD ?= "armored-witness"
 
 APP := ""
-TEXT_START := 0x80010000 # ramStart (defined in mem.go under relevant tamago/soc package) + 0x10000
+TEXT_START = 0x90010000 # ramStart (defined in mem.go under relevant tamago/soc package) + 0x10000
+
+ifeq ("${BEE}","1")
+	TEXT_START := 0x10010000
+	BUILD_TAGS := ${BUILD_TAGS},bee
+endif
 
 GOENV := GO_EXTLINK_ENABLED=0 CGO_ENABLED=0 GOOS=tamago GOARM=7 GOARCH=arm
 ENTRY_POINT := _rt0_arm_tamago
@@ -45,7 +50,6 @@ elf: $(APP).elf
 
 trusted_applet: APP=trusted_applet
 trusted_applet: DIR=$(CURDIR)/trusted_applet
-trusted_applet: TEXT_START=0x90010000
 trusted_applet: check_applet_env elf
 	echo "signing Trusted Applet"
 	@if [ "${SIGN_PWD}" != "" ]; then \

--- a/trusted_applet/bee.go
+++ b/trusted_applet/bee.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !bee
-// +build !bee
+//go:build bee
+// +build bee
 
 package main
 
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	appletStart = 0x90000000
+	appletStart = 0x20000000
 	appletSize  = 0x10000000 // 256MB
 )
 
@@ -31,6 +31,3 @@ var ramStart uint32 = appletStart
 
 //go:linkname ramSize runtime.ramSize
 var ramSize uint32 = appletSize
-
-//go:linkname ramStackOffset runtime.ramStackOffset
-var ramStackOffset uint32 = 0x100

--- a/trusted_applet/mem_bee.go
+++ b/trusted_applet/mem_bee.go
@@ -21,6 +21,9 @@ import (
 	_ "unsafe"
 )
 
+// The following memory region is within an alias of external DDR, required
+// when memory encryption is enforced by the i.MX6UL Bus Encryption Engine
+// (BEE).
 const (
 	appletStart = 0x20000000
 	appletSize  = 0x10000000 // 256MB


### PR DESCRIPTION
This commit supports [amored-witness-boot PR #12](https://github.com/transparency-dev/armored-witness-boot/pull/12) by adding optional compile time flags to support BEE aliased regions.