### PR TITLE
Omni tweaks

### DIFF
--- a/trusted_applet/main.go
+++ b/trusted_applet/main.go
@@ -76,7 +76,9 @@ func init() {
 }
 
 func main() {
+	flag.Set("vmodule", "journal=1,slots=1")
 	flag.Set("v", "1")
+	flag.Set("logtostderr", "true")
 	flag.Parse()
 
 	ctx := context.Background()

--- a/trusted_applet/main.go
+++ b/trusted_applet/main.go
@@ -221,15 +221,11 @@ func runWithNetworking(ctx context.Context) error {
 		return fmt.Errorf("could not initialize HTTP listener: %v", err)
 	}
 
-	go func() {
-		log.Println("Starting witness...")
-		if err := omniwitness.Main(ctx, opConfig, persistence, mainListener, httpClient); err != nil {
-			// TODO: surface this
-			glog.Exitf("Main failed: %v", err)
-		}
-	}()
+	log.Println("Starting witness...")
+	if err := omniwitness.Main(ctx, opConfig, persistence, mainListener, httpClient); err != nil {
+		return fmt.Errorf("omniwitness.Main failed: %v", err)
+	}
 
-	<-ctx.Done()
 	return ctx.Err()
 }
 

--- a/trusted_applet/main.go
+++ b/trusted_applet/main.go
@@ -169,7 +169,7 @@ func main() {
 		runDHCP(ctx, nicID, runWithNetworking)
 	} else {
 		if err := runWithNetworking(ctx); err != nil && err != context.Canceled {
-			log.Printf("runWithNetworking: %v", err)
+			glog.Exitf("runWithNetworking: %v", err)
 		}
 	}
 }
@@ -205,11 +205,11 @@ func runWithNetworking(ctx context.Context) error {
 
 	signer, err := note.NewSigner(signingKey)
 	if err != nil {
-		glog.Exitf("Failed to init signer: %v", err)
+		return fmt.Errorf("failed to init signer: %v", err)
 	}
 	verifier, err := note.NewVerifier(publicKey)
 	if err != nil {
-		glog.Exitf("Failed to init verifier: %v", err)
+		return fmt.Errorf("failed to init verifier: %v", err)
 	}
 	opConfig := omniwitness.OperatorConfig{
 		WitnessSigner:   signer,
@@ -218,12 +218,13 @@ func runWithNetworking(ctx context.Context) error {
 	// TODO(mhutchinson): add a second listener for an admin API.
 	mainListener, err := iface.ListenerTCP4(80)
 	if err != nil {
-		glog.Exitf("could not initialize HTTP listener: %v", err)
+		return fmt.Errorf("could not initialize HTTP listener: %v", err)
 	}
 
 	go func() {
 		log.Println("Starting witness...")
 		if err := omniwitness.Main(ctx, opConfig, persistence, mainListener, httpClient); err != nil {
+			// TODO: surface this
 			glog.Exitf("Main failed: %v", err)
 		}
 	}()


### PR DESCRIPTION
- return errors from `runWithNetworking` rather than bomb out
- run `omniwitness.Main` inline