### PR TITLE
Only re-read the entry which was just written

### DIFF
--- a/trusted_applet/internal/storage/slots/journal.go
+++ b/trusted_applet/internal/storage/slots/journal.go
@@ -159,16 +159,25 @@ func (j *Journal) Update(data []byte) error {
 	if err := marshalEntry(e, buf); err != nil {
 		return fmt.Errorf("failed to marshal entry: %v", err)
 	}
-	if err := j.dev.WriteBlocks(j.nextBlock, buf.Bytes()); err != nil {
+	numBlocks, err := j.dev.WriteBlocks(j.nextBlock, buf.Bytes())
+	if err != nil {
 		return fmt.Errorf("failed to write blocks: %v", err)
 	}
-	// Finally, we'll rescan the journal and make sure that all is well.
-	if err := j.init(); err != nil {
-		return fmt.Errorf("failed to re-scan journal: %v", err)
+
+	// Attempt to re-read the entry we just wrote to make sure that all is well...
+	br := newBlockReader(j.dev, j.nextBlock)
+	latest, err := unmarshalEntry(br)
+	if err != nil {
+		return fmt.Errorf("failed to re-scan written entry: %v", err)
 	}
-	if got, want := j.current.Revision, e.Revision; got != want {
+	if got, want := latest.Revision, e.Revision; got != want {
 		return fmt.Errorf("journal error, latest entry revision %d != written revision %d", got, want)
 	}
+
+	// Finally, update the journal state.
+	j.nextBlock += numBlocks
+	j.current = *latest
+
 	return nil
 }
 

--- a/trusted_applet/internal/storage/slots/journal.go
+++ b/trusted_applet/internal/storage/slots/journal.go
@@ -43,7 +43,8 @@ type BlockReaderWriter interface {
 	// WriteBlocks writes len(b) bytes from b to contiguous storage blocks starting
 	// at the given block address.
 	// b must be an integer multiple of the device's block size.
-	WriteBlocks(lba uint, b []byte) error
+	// Returns the number of blocks written, or an error.
+	WriteBlocks(lba uint, b []byte) (uint, error)
 }
 
 // Journal implements a record-based format which provides a resilient storage.

--- a/trusted_applet/internal/storage/slots/slots.go
+++ b/trusted_applet/internal/storage/slots/slots.go
@@ -96,7 +96,7 @@ func (p *Partition) Erase() error {
 		length := p.slots[i].journal.length
 		start := p.slots[i].journal.start
 		b := make([]byte, length)
-		if err := p.dev.WriteBlocks(start, b); err != nil {
+		if _, err := p.dev.WriteBlocks(start, b); err != nil {
 			glog.Warningf("Failed to wipe slot %d occupying blocks [%d, %d): %v", i, start, start+length, err)
 			borked = true
 		}

--- a/trusted_applet/internal/storage/slots/slots_test.go
+++ b/trusted_applet/internal/storage/slots/slots_test.go
@@ -98,7 +98,7 @@ func TestOpenPartition(t *testing.T) {
 	}
 }
 
-func memPartition(t *testing.T) (*Partition, testonly.MemDev) {
+func memPartition(t *testing.T) (*Partition, *testonly.MemDev) {
 	t.Helper()
 	md := testonly.NewMemDev(t, 32)
 	geo := Geometry{

--- a/trusted_applet/internal/storage/testonly/memdev.go
+++ b/trusted_applet/internal/storage/testonly/memdev.go
@@ -52,9 +52,9 @@ func (md MemDev) ReadBlocks(lba uint, b []byte) error {
 // WriteBlocks writes len(b) bytes from b to contiguous storage blocks starting
 // at the given block address.
 // b must be an integer multiple of the device's block size.
-func (md MemDev) WriteBlocks(lba uint, b []byte) error {
+func (md MemDev) WriteBlocks(lba uint, b []byte) (uint, error) {
 	if lba >= uint(len(md)) {
-		return fmt.Errorf("lba (%d) >= device blocks (%d)", lba, len(md))
+		return 0, fmt.Errorf("lba (%d) >= device blocks (%d)", lba, len(md))
 	}
 	// If the data isn't a multiple of the blocksize, pad it up
 	// so that it is.
@@ -69,7 +69,7 @@ func (md MemDev) WriteBlocks(lba uint, b []byte) error {
 	for i := uint(0); i < bl; i++ {
 		copy(md[lba+i][:], b[i*MemBlockSize:])
 	}
-	return nil
+	return bl, nil
 }
 
 // NewMemDev creates a new in-memory block device.

--- a/trusted_applet/internal/storage/testonly/memdev.go
+++ b/trusted_applet/internal/storage/testonly/memdev.go
@@ -52,6 +52,8 @@ func (md MemDev) ReadBlocks(lba uint, b []byte) error {
 // WriteBlocks writes len(b) bytes from b to contiguous storage blocks starting
 // at the given block address.
 // b must be an integer multiple of the device's block size.
+//
+// Returns the number of blocks written, or an error.
 func (md MemDev) WriteBlocks(lba uint, b []byte) (uint, error) {
 	if lba >= uint(len(md)) {
 		return 0, fmt.Errorf("lba (%d) >= device blocks (%d)", lba, len(md))

--- a/trusted_applet/internal/storage/testonly/memdev.go
+++ b/trusted_applet/internal/storage/testonly/memdev.go
@@ -24,7 +24,12 @@ import (
 const MemBlockSize = 512
 
 // MemDev is a simple in-memory block device.
-type MemDev [][MemBlockSize]byte
+type MemDev struct {
+	Storage [][MemBlockSize]byte
+
+	// OnBlockWritten is called just after a mem block has been written.
+	OnBlockWritten func(lba uint)
+}
 
 // BlockSize returns the block size of the underlying storage system.
 func (md MemDev) BlockSize() uint {
@@ -35,16 +40,16 @@ func (md MemDev) BlockSize() uint {
 // at the given block address.
 // b must be an integer multiple of the device's block size.
 func (md MemDev) ReadBlocks(lba uint, b []byte) error {
-	if lba >= uint(len(md)) {
-		return fmt.Errorf("lba (%d) >= device blocks (%d)", lba, len(md))
+	if lba >= uint(len(md.Storage)) {
+		return fmt.Errorf("lba (%d) >= device blocks (%d)", lba, len(md.Storage))
 	}
 	lenB := uint(len(b))
 	bl := lenB / MemBlockSize
-	if l := uint(len(md)); lba+bl > l {
+	if l := uint(len(md.Storage)); lba+bl > l {
 		bl = l - lba
 	}
 	for i := uint(0); i < bl; i++ {
-		copy(b[i*MemBlockSize:], md[lba+i][:])
+		copy(b[i*MemBlockSize:], md.Storage[lba+i][:])
 	}
 	return nil
 }
@@ -55,8 +60,8 @@ func (md MemDev) ReadBlocks(lba uint, b []byte) error {
 //
 // Returns the number of blocks written, or an error.
 func (md MemDev) WriteBlocks(lba uint, b []byte) (uint, error) {
-	if lba >= uint(len(md)) {
-		return 0, fmt.Errorf("lba (%d) >= device blocks (%d)", lba, len(md))
+	if lba >= uint(len(md.Storage)) {
+		return 0, fmt.Errorf("lba (%d) >= device blocks (%d)", lba, len(md.Storage))
 	}
 	// If the data isn't a multiple of the blocksize, pad it up
 	// so that it is.
@@ -65,17 +70,20 @@ func (md MemDev) WriteBlocks(lba uint, b []byte) (uint, error) {
 	}
 	lenB := uint(len(b))
 	bl := lenB / MemBlockSize
-	if l := uint(len(md)); lba+bl > l {
+	if l := uint(len(md.Storage)); lba+bl > l {
 		bl = l - lba
 	}
 	for i := uint(0); i < bl; i++ {
-		copy(md[lba+i][:], b[i*MemBlockSize:])
+		copy(md.Storage[lba+i][:], b[i*MemBlockSize:])
+		if md.OnBlockWritten != nil {
+			md.OnBlockWritten(lba + i)
+		}
 	}
 	return bl, nil
 }
 
 // NewMemDev creates a new in-memory block device.
-func NewMemDev(t *testing.T, numBlocks uint) MemDev {
+func NewMemDev(t *testing.T, numBlocks uint) *MemDev {
 	t.Helper()
-	return make(MemDev, numBlocks)
+	return &MemDev{Storage: make([][MemBlockSize]byte, numBlocks)}
 }


### PR DESCRIPTION
Previously, the entire journal would be re-scanned from the beginning in order to verify that writing a new entry was successful. Depending on the size of the journal/number of entries it contains, this could take a while.

This PR improves that by only re-reading the written entry.