### PR TITLE
Fix signify key generation command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ environment variables must be set to the path of either
 Example key generation (signify):
 
 ```
-signify -G -n -p armored-witness-applet.pub -s armores-witness-applet.sec
+signify -G -n -p armored-witness-applet.pub -s armored-witness-applet.sec
 ```
 
 Example key generation (minisign):

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ environment variables must be set to the path of either
 Example key generation (signify):
 
 ```
-signify -G -p armored-witness-applet.pub -s armores-witness-applet.sec
+signify -G -n -p armored-witness-applet.pub -s armores-witness-applet.sec
 ```
 
 Example key generation (minisign):


### PR DESCRIPTION
Currently errors with `signify-openbsd: please use naming scheme of keyname.pub and keyname.sec`.