### PR TITLE
Add support for optionally enabling the GH distributor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,11 @@ ENTRY_POINT := _rt0_arm_tamago
 
 ARCH = "arm"
 
-GOFLAGS = -tags ${BUILD_TAGS} -trimpath -ldflags "-T ${TEXT_START} -E ${ENTRY_POINT} -R 0x1000 -X 'main.Build=${BUILD}' -X 'main.Revision=${REV}' -X 'main.Version=${BUILD_EPOCH}' -X 'main.PublicKey=$(shell test ${PUBLIC_KEY} && cat ${PUBLIC_KEY} | tail -n 1)'"
+GOFLAGS = -tags ${BUILD_TAGS} -trimpath \
+        -ldflags "-T ${TEXT_START} -E ${ENTRY_POINT} -R 0x1000 \
+                  -X 'main.Build=${BUILD}' -X 'main.Revision=${REV}' -X 'main.Version=${BUILD_EPOCH}' \
+		          -X 'main.PublicKey=$(shell test ${PUBLIC_KEY} && cat ${PUBLIC_KEY} | tail -n 1)' \
+		          -X 'main.GitHubUser=${GITHUB_USER}' -X 'main.GitHubEmail=${GITHUB_EMAIL}' -X 'main.GitHubToken=${GITHUB_TOKEN}'"
 
 .PHONY: clean
 

--- a/trusted_applet/main.go
+++ b/trusted_applet/main.go
@@ -66,6 +66,8 @@ var (
 	Revision string
 	Version  string
 
+	GitHubUser, GitHubEmail, GitHubToken string
+
 	cfg *api.Configuration
 
 	persistence *storage.SlotPersistence
@@ -229,6 +231,9 @@ func runWithNetworking(ctx context.Context) error {
 	opConfig := omniwitness.OperatorConfig{
 		WitnessSigner:   signer,
 		WitnessVerifier: verifier,
+		GithubUser:      GitHubUser,
+		GithubEmail:     GitHubEmail,
+		GithubToken:     GitHubToken,
 	}
 	// TODO(mhutchinson): add a second listener for an admin API.
 	mainListener, err := iface.ListenerTCP4(80)


### PR DESCRIPTION
This adds 3 ENV vars which can optionally be set to bake in github creds during the build.

`GITHUB_USER`, `GITHUB_EMAIL`, and `GITHUB_TOKEN`

This is a temporary thing and can be removed once we have the new restful distributor implemented and running somewhere.