### PR TITLE
Bump gVisor to v0.0.0-20230614190805-57027c7d31f8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	google.golang.org/grpc v1.55.0
 	google.golang.org/protobuf v1.30.0
 	gopkg.in/yaml.v3 v3.0.1
-	gvisor.dev/gvisor v0.0.0-20230315045701-8b73c1d89ca8
+	gvisor.dev/gvisor v0.0.0-20230614011150-2ccb90afa11e
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/transparency-dev/armored-witness-os v0.0.0-20230608161615-85a962a3140d
 	github.com/transparency-dev/witness v0.0.0-20230607113817-0b70a97dae5f
 	github.com/usbarmory/GoTEE v0.0.0-20230127101228-519e560d69aa
-	github.com/usbarmory/imx-enet v0.0.0-20230525204907-2882ea9be008
+	github.com/usbarmory/imx-enet v0.0.0-20230615131844-0373d79f7198
 	github.com/usbarmory/tamago v0.0.0-20230529110145-b8025086bb9f
 	golang.org/x/crypto v0.9.0
 	golang.org/x/mod v0.10.0
@@ -18,7 +18,7 @@ require (
 	google.golang.org/grpc v1.55.0
 	google.golang.org/protobuf v1.30.0
 	gopkg.in/yaml.v3 v3.0.1
-	gvisor.dev/gvisor v0.0.0-20230614011150-2ccb90afa11e
+	gvisor.dev/gvisor v0.0.0-20230614190805-57027c7d31f8
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/usbarmory/GoTEE v0.0.0-20230127101228-519e560d69aa h1:iWvxAk3sE4mvCYV
 github.com/usbarmory/GoTEE v0.0.0-20230127101228-519e560d69aa/go.mod h1:164CE5Gb+PiM6cxhYpyPg9FlpqttRFwUZ+KiTonK4Ak=
 github.com/usbarmory/imx-enet v0.0.0-20230525204907-2882ea9be008 h1:l5lO1CrlMbW35ee1bPOe2zTN+t7YFgF9oNYvRIo7Cqc=
 github.com/usbarmory/imx-enet v0.0.0-20230525204907-2882ea9be008/go.mod h1:oa7S6vwmh5KtGcZDluDIZ6P2xjI/hzVTB2SNohFYd58=
+github.com/usbarmory/imx-enet v0.0.0-20230615131844-0373d79f7198 h1:g5J22Bwmvr9zJHw3mkTsNmzayu/Sv1TGpKwjQsyExME=
+github.com/usbarmory/imx-enet v0.0.0-20230615131844-0373d79f7198/go.mod h1:T7T/0Fejbnj4y/uIVDcNPT1gnKNMmPsYnnshdWFuz+o=
 github.com/usbarmory/tamago v0.0.0-20220823080407-04f05cf2a5a3/go.mod h1:Lok79mjbJnhoBGqhX5cCUsZtSemsQF5FNZW+2R1dRr8=
 github.com/usbarmory/tamago v0.0.0-20230529110145-b8025086bb9f h1:2nCLV3Jp6rFZC6fk34ClkqBTF1IpWBm5dI+bPHxBQkE=
 github.com/usbarmory/tamago v0.0.0-20230529110145-b8025086bb9f/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
@@ -141,3 +143,5 @@ gvisor.dev/gvisor v0.0.0-20230315045701-8b73c1d89ca8 h1:vh1Ek1+dC8oCgLixyCRnNxcM
 gvisor.dev/gvisor v0.0.0-20230315045701-8b73c1d89ca8/go.mod h1:pzr6sy8gDLfVmDAg8OYrlKvGEHw5C3PGTiBXBTCx76Q=
 gvisor.dev/gvisor v0.0.0-20230614011150-2ccb90afa11e h1:eJ7mQJJ1ifUJKoVuJd9QozB3kqxB/Qtw8Fm+3zN5Gdg=
 gvisor.dev/gvisor v0.0.0-20230614011150-2ccb90afa11e/go.mod h1:sQuqOkxbfJq/GS2uSnqHphtXclHyk/ZrAGhZBxxsq6g=
+gvisor.dev/gvisor v0.0.0-20230614190805-57027c7d31f8 h1:cycLSWR8fzi6P+jQ9vaD82frUFZ0UU1kDZt1YPWFFhA=
+gvisor.dev/gvisor v0.0.0-20230614190805-57027c7d31f8/go.mod h1:sQuqOkxbfJq/GS2uSnqHphtXclHyk/ZrAGhZBxxsq6g=

--- a/go.sum
+++ b/go.sum
@@ -139,3 +139,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gvisor.dev/gvisor v0.0.0-20230315045701-8b73c1d89ca8 h1:vh1Ek1+dC8oCgLixyCRnNxcMOIBwQV59vkD6JeTyoQI=
 gvisor.dev/gvisor v0.0.0-20230315045701-8b73c1d89ca8/go.mod h1:pzr6sy8gDLfVmDAg8OYrlKvGEHw5C3PGTiBXBTCx76Q=
+gvisor.dev/gvisor v0.0.0-20230614011150-2ccb90afa11e h1:eJ7mQJJ1ifUJKoVuJd9QozB3kqxB/Qtw8Fm+3zN5Gdg=
+gvisor.dev/gvisor v0.0.0-20230614011150-2ccb90afa11e/go.mod h1:sQuqOkxbfJq/GS2uSnqHphtXclHyk/ZrAGhZBxxsq6g=

--- a/third_party/dhcp/dhcp.go
+++ b/third_party/dhcp/dhcp.go
@@ -64,17 +64,17 @@ func (cfg *Config) decode(opts []option) error {
 		case optRebindingTime:
 			cfg.RebindTime = Seconds(binary.BigEndian.Uint32(b))
 		case optSubnetMask:
-			cfg.SubnetMask = tcpip.AddressMask(b)
+			cfg.SubnetMask = tcpip.MaskFromBytes(b)
 		case optDHCPServer:
-			cfg.ServerAddress = tcpip.Address(b)
+			cfg.ServerAddress = tcpip.AddrFromSlice(b)
 		case optRouter:
 			for len(b) != 0 {
-				cfg.Router = append(cfg.Router, tcpip.Address(b[:4]))
+				cfg.Router = append(cfg.Router, tcpip.AddrFromSlice(b[:4]))
 				b = b[4:]
 			}
 		case optDomainNameServer:
 			for len(b) != 0 {
-				cfg.DNS = append(cfg.DNS, tcpip.Address(b[:4]))
+				cfg.DNS = append(cfg.DNS, tcpip.AddrFromSlice(b[:4]))
 				b = b[4:]
 			}
 		}
@@ -83,23 +83,23 @@ func (cfg *Config) decode(opts []option) error {
 }
 
 func (cfg Config) encode() (opts []option) {
-	if cfg.ServerAddress != "" {
-		opts = append(opts, option{optDHCPServer, []byte(cfg.ServerAddress)})
+	if cfg.ServerAddress.Len() > 0 {
+		opts = append(opts, option{optDHCPServer, []byte(cfg.ServerAddress.AsSlice())})
 	}
-	if cfg.SubnetMask != "" {
-		opts = append(opts, option{optSubnetMask, []byte(cfg.SubnetMask)})
+	if cfg.SubnetMask.Len() > 0 {
+		opts = append(opts, option{optSubnetMask, []byte(cfg.SubnetMask.AsSlice())})
 	}
 	if len(cfg.Router) > 0 {
 		router := make([]byte, 0, 4*len(cfg.Router))
 		for _, addr := range cfg.Router {
-			router = append(router, addr...)
+			router = append(router, addr.AsSlice()...)
 		}
 		opts = append(opts, option{optRouter, router})
 	}
 	if len(cfg.DNS) > 0 {
 		dns := make([]byte, 0, 4*len(cfg.DNS))
 		for _, addr := range cfg.DNS {
-			dns = append(dns, addr...)
+			dns = append(dns, addr.AsSlice()...)
 		}
 		opts = append(opts, option{optDomainNameServer, dns})
 	}
@@ -242,10 +242,10 @@ func (h hdr) String() string {
 		&buf,
 		"type=%s;ciaddr=%s;yiaddr=%s;siaddr=%s;giaddr=%s;chaddr=%x",
 		msgType,
-		tcpip.Address(h.ciaddr()),
-		tcpip.Address(h.yiaddr()),
-		tcpip.Address(h.siaddr()),
-		tcpip.Address(h.giaddr()),
+		tcpip.AddrFromSlice(h.ciaddr()),
+		tcpip.AddrFromSlice(h.yiaddr()),
+		tcpip.AddrFromSlice(h.siaddr()),
+		tcpip.AddrFromSlice(h.giaddr()),
 		h.chaddr(),
 	); err != nil {
 		panic(err)

--- a/trusted_applet/main.go
+++ b/trusted_applet/main.go
@@ -209,6 +209,8 @@ func runWithNetworking(ctx context.Context) error {
 
 	<-runNTP(ctx)
 
+	time.Sleep(5 * time.Second)
+
 	listener, err := iface.ListenerTCP4(22)
 	if err != nil {
 		return fmt.Errorf("TA could not initialize SSH listener, %v", err)

--- a/trusted_applet/net.go
+++ b/trusted_applet/net.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"time"
 
-	"gvisor.dev/gvisor/pkg/bufferv2"
+	"gvisor.dev/gvisor/pkg/buffer"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
@@ -386,7 +386,7 @@ func rx(buf []byte) {
 
 	pkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
 		ReserveHeaderBytes: len(hdr),
-		Payload:            bufferv2.MakeWithData(payload),
+		Payload:            buffer.MakeWithData(payload),
 	})
 
 	copy(pkt.LinkHeader().Push(len(hdr)), hdr)


### PR DESCRIPTION
- Update to recent gVisor
- Bump imx-enet, which has been updated to a recent gVisor
- Fixup a number of breaking gVisor API changes, e.g.:
  - `bufferv2` has gone, so rework onto `buffer`
  - types which were aliases of `[]byte` are now structs