### PR TITLE
Add write to transparency log after building and signing.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -58,13 +58,15 @@ steps:
       - cp
       - output/trusted_applet.sig
       - gs://${_TRUSTED_APPLET_BUCKET}/${TAG_NAME}/trusted_applet.sig
-      # Construct log entry / Claimant Model statement.
+  # Construct log entry / Claimant Model statement.
+  # TODO(jayhou): replace this with a more programmatic JSON construction. `firmware_digest_sha256`
+  # should be in base64 instead of hex.
   - name: 'ubuntu'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
-        echo -e "{\n  \"component\": \"TRUSTED_APPLET\"\n  \"git_tag_name\": \"${TAG_NAME}\"\n  \"git_commit_fingerprint\": \"${COMMIT_SHA}\"\n  \"firmware_digest_sha256\": \"$(sha256sum -b output/trusted_applet.elf | cut -d " " -f1)\"\n  \"tamago_version\": \"${_TAMAGO_VERSION}\"\n}" > output/applet_log_entry
+        echo -e "{\n  \"component\": \"TRUSTED_APPLET\",\n  \"git_tag_name\": \"${TAG_NAME}\",\n  \"git_commit_fingerprint\": \"${COMMIT_SHA}\",\n  \"firmware_digest_sha256\": \"$(sha256sum -b output/trusted_applet.elf | cut -d ' ' -f1)\",\n  \"tamago_version\": \"${_TAMAGO_VERSION}\"\n}" > output/applet_log_entry
   # Copy log entry to the sequence bucket, preparing to write to log.
   - name: gcr.io/cloud-builders/gcloud
     args:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -64,7 +64,7 @@ steps:
     args:
       - '-c'
       - |
-        echo -e "{\n  \"sha256_digest\": \"$(sha256sum -b output/trusted_applet.elf | cut -d " " -f1)\"\n  \"tag_name\": \"${TAG_NAME}\"\n  \"tamago_version\": \"${_TAMAGO_VERSION}\"\n}" > output/applet_log_entry
+        echo -e "{\n  \"revision_id\": \"${REVISION_ID}\"\n  \"commit_sha\": \"${COMMIT_SHA}\"\n \"sha256_digest\": \"$(sha256sum -b output/trusted_applet.elf | cut -d " " -f1)\"\n  \"tag_name\": \"${TAG_NAME}\"\n  \"tamago_version\": \"${_TAMAGO_VERSION}\"\n  \"component\": \"TRUSTED_APPLET\"\n"}" > output/applet_log_entry
   # Copy log entry to the sequence bucket, preparing to write to log.
   - name: gcr.io/cloud-builders/gcloud
     args:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -64,7 +64,7 @@ steps:
     args:
       - '-c'
       - |
-        echo -e "{\n  \"revision_id\": \"${REVISION_ID}\"\n  \"commit_sha\": \"${COMMIT_SHA}\"\n \"sha256_digest\": \"$(sha256sum -b output/trusted_applet.elf | cut -d " " -f1)\"\n  \"tag_name\": \"${TAG_NAME}\"\n  \"tamago_version\": \"${_TAMAGO_VERSION}\"\n  \"component\": \"TRUSTED_APPLET\"\n"}" > output/applet_log_entry
+        echo -e "{\n  \"component\": \"TRUSTED_APPLET\"\n  \"tag_name\": \"${TAG_NAME}\"\n  \"commit_sha\": \"${COMMIT_SHA}\"\n  \"sha256_digest\": \"$(sha256sum -b output/trusted_applet.elf | cut -d " " -f1)\"\n  \"tamago_version\": \"${_TAMAGO_VERSION}\"\n}" > output/applet_log_entry
   # Copy log entry to the sequence bucket, preparing to write to log.
   - name: gcr.io/cloud-builders/gcloud
     args:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -58,12 +58,47 @@ steps:
       - cp
       - output/trusted_applet.sig
       - gs://${_TRUSTED_APPLET_BUCKET}/${TAG_NAME}/trusted_applet.sig
-
+      # Construct log entry / Claimant Model statement.
+  - name: 'ubuntu'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        echo -e "{\n  digest: $(sha256sum -b output/trusted_applet.elf),\n  tag_name: ${TAG_NAME},\n  tamago_version: ${_TAMAGO_VERSION},\n}" > output/applet_log_entry
+  # Copy log entry to the sequence bucket, preparing to write to log.
+  - name: gcr.io/cloud-builders/gcloud
+    args:
+      - storage
+      - cp
+      - output/applet_log_entry
+      - 'gs://${_LOG_NAME}/${_ENTRIES_DIR}/applet_log_entry'
+  # Sequence log entry.
+  - name: gcr.io/cloud-builders/gcloud
+    args:
+      - functions
+      - call
+      - sequence
+      - '--data'
+      - '{"entriesDir": "${_ENTRIES_DIR}", "origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}"}'
+  # Integrate log entry.
+  - name: gcr.io/cloud-builders/gcloud
+    args:
+      - functions
+      - call
+      - integrate
+      - '--data'
+      - '{"origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}"}'
 substitutions:
+  # Build-related.
   _ARTIFACT_REGISTRY_REPO: trusted-applet-builder
-  _KMS_KEY: trusted-applet
-  _KMS_KEYRING: armored-witness
-  _KMS_KEY_VERSION: '1'
   _REGION: europe-west2
   _TRUSTED_APPLET_BUCKET: trusted-applet-artifacts
   _TAMAGO_VERSION: '1.20.6'
+  # Signing-related.
+  _KMS_KEY: trusted-applet
+  _KMS_KEYRING: armored-witness
+  _KMS_KEY_VERSION: '1'
+  # Log-related.
+  _ENTRIES_DIR: firmware-log-sequence
+  _ORIGIN: transparency.dev/armored-witness/binary_transparency/0
+  _LOG_NAME: firmware-log

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -64,8 +64,7 @@ steps:
     args:
       - '-c'
       - |
-        cp output/trusted_applet.elf . && \
-        echo -e "{\n  digest: $(sha256sum -b trusted_applet.elf),\n  tag_name: ${TAG_NAME},\n  tamago_version: ${_TAMAGO_VERSION},\n}" > output/applet_log_entry
+        echo -e "{\n  \"sha256_digest\": \"$(sha256sum -b output/trusted_applet.elf | cut -d " " -f1)\"\n  \"tag_name\": \"${TAG_NAME}\"\n  \"tamago_version\": \"${_TAMAGO_VERSION}\"\n}" > output/applet_log_entry
   # Copy log entry to the sequence bucket, preparing to write to log.
   - name: gcr.io/cloud-builders/gcloud
     args:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -64,7 +64,8 @@ steps:
     args:
       - '-c'
       - |
-        echo -e "{\n  digest: $(sha256sum -b output/trusted_applet.elf),\n  tag_name: ${TAG_NAME},\n  tamago_version: ${_TAMAGO_VERSION},\n}" > output/applet_log_entry
+        cp output/trusted_applet.elf . && \
+        echo -e "{\n  digest: $(sha256sum -b trusted_applet.elf),\n  tag_name: ${TAG_NAME},\n  tamago_version: ${_TAMAGO_VERSION},\n}" > output/applet_log_entry
   # Copy log entry to the sequence bucket, preparing to write to log.
   - name: gcr.io/cloud-builders/gcloud
     args:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -64,7 +64,7 @@ steps:
     args:
       - '-c'
       - |
-        echo -e "{\n  \"component\": \"TRUSTED_APPLET\"\n  \"tag_name\": \"${TAG_NAME}\"\n  \"commit_sha\": \"${COMMIT_SHA}\"\n  \"sha256_digest\": \"$(sha256sum -b output/trusted_applet.elf | cut -d " " -f1)\"\n  \"tamago_version\": \"${_TAMAGO_VERSION}\"\n}" > output/applet_log_entry
+        echo -e "{\n  \"component\": \"TRUSTED_APPLET\"\n  \"git_tag_name\": \"${TAG_NAME}\"\n  \"git_commit_fingerprint\": \"${COMMIT_SHA}\"\n  \"firmware_digest_sha256\": \"$(sha256sum -b output/trusted_applet.elf | cut -d " " -f1)\"\n  \"tamago_version\": \"${_TAMAGO_VERSION}\"\n}" > output/applet_log_entry
   # Copy log entry to the sequence bucket, preparing to write to log.
   - name: gcr.io/cloud-builders/gcloud
     args:


### PR DESCRIPTION
Callouts to a few things proposed in this PR:

* Origin: `transparency.dev/armored-witness/binary_transparency/0`
* Example Claimant Model statement (TAG_NAME is blank in development, should not be in production):
[firmware-log-sequence_applet_log_entry.txt](https://github.com/transparency-dev/armored-witness-applet/files/12163933/firmware-log-sequence_applet_log_entry.txt)

The output of the digest from `sha256sum` includes the filename as well, thinking of stripping that (but would need to add a field to indicate what this is, e.g. trust_applet, trusted_os)?