### PR TITLE
API struct to represent the firmware manifest

### DIFF
--- a/api/example_firmware_release.json
+++ b/api/example_firmware_release.json
@@ -1,7 +1,7 @@
 {
     "component": "TRUSTED_APPLET",
     "git_tag_name": "0.1.2",
-    "git_commit_sha": "aac1e176cfac1a1e079b5f624b83fda54b5d0f76",
+    "git_commit_fingerprint": "aac1e176cfac1a1e079b5f624b83fda54b5d0f76",
     "firmware_digest_sha256": "8l4TaroPsSq+zwG+XMPZw+EdpUoXH0IT4cKM2RmFyNE=",
     "tamago_version": "1.20.6"
 }

--- a/api/example_firmware_release.json
+++ b/api/example_firmware_release.json
@@ -2,6 +2,6 @@
     "component": "TRUSTED_APPLET",
     "tag_name": "0.1.2",
     "commit_sha": "aac1e176cfac1a1e079b5f624b83fda54b5d0f76",
-    "sha256_digest": "f25e136aba0fb12abecf01be5cc3d9c3e11da54a171f4213e1c28cd91985c8d1",
+    "sha256_digest": "8l4TaroPsSq+zwG+XMPZw+EdpUoXH0IT4cKM2RmFyNE=",
     "tamago_version": "1.20.6"
 }

--- a/api/example_firmware_release.json
+++ b/api/example_firmware_release.json
@@ -1,0 +1,7 @@
+{
+    "component": "TRUSTED_APPLET",
+    "tag_name": "0.1.2",
+    "commit_sha": "aac1e176cfac1a1e079b5f624b83fda54b5d0f76",
+    "sha256_digest": "f25e136aba0fb12abecf01be5cc3d9c3e11da54a171f4213e1c28cd91985c8d1",
+    "tamago_version": "1.20.6"
+}

--- a/api/example_firmware_release.json
+++ b/api/example_firmware_release.json
@@ -1,7 +1,7 @@
 {
     "component": "TRUSTED_APPLET",
-    "tag_name": "0.1.2",
-    "commit_sha": "aac1e176cfac1a1e079b5f624b83fda54b5d0f76",
-    "sha256_digest": "8l4TaroPsSq+zwG+XMPZw+EdpUoXH0IT4cKM2RmFyNE=",
+    "git_tag_name": "0.1.2",
+    "git_commit_sha": "aac1e176cfac1a1e079b5f624b83fda54b5d0f76",
+    "firmware_digest_sha256": "8l4TaroPsSq+zwG+XMPZw+EdpUoXH0IT4cKM2RmFyNE=",
     "tamago_version": "1.20.6"
 }

--- a/api/log_entries.go
+++ b/api/log_entries.go
@@ -1,0 +1,57 @@
+// Copyright 2023 The Armored Witness Applet authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package api contains public structures related to the log contents.
+package api
+
+const (
+	// Component name for the applet used in FirmwareRelease.Component.
+	ComponentApplet = "TRUSTED_APPLET"
+)
+
+// FirmwareRelease represents a firmware release in the log.
+type FirmwareRelease struct {
+	// Component identifies the type of firmware (e.g. OS or applet).
+	// This component is key to disambiguate what the firmware is, and other
+	// implicit information can be derived from this. For example, the git
+	// repository that the code should be checked out from to reproduce the
+	// build.
+	Component string `json:"component"`
+
+	// TagName identifies the version of this release, e.g. "0.1.2"
+	TagName string `json:"tag_name"`
+
+	// CommitHash contains the SHA256 commit hash of the git repository when checked
+	// out at TagName. Committing to this information allows verifiers that cannot
+	// reproduce a build to quickly narrow down the problem space:
+	//  - if this CommitHash is different then they have checked out different code
+	//    than was used to build the binary. This could happen if the wrong repo was
+	//    used, or because the TagName was changed to a different commit
+	//  - if the CommitHash is the same, then they have the same code checked out but
+	//    there is a problem with the build toolchain (different tooling or non-reproducible
+	//    builds).
+	CommitHash []byte `json:"commit_sha"`
+
+	// Sha256Digest is the hash of the compiled firmware binary. Believers that are
+	// installing a firmware release must check that the firmware data they are going to
+	// believe has a fingerprint matching this hash. Verifiers that check out the correct
+	// source repo & version must be able to reproducibly build a binary that has this fingerprint.
+	Sha256Digest []byte `json:"sha256_digest"`
+
+	// TamagoVersion identifies the version of [Tamago] that the builder used to compile
+	// the binary with Sha256Digest.
+	//
+	// [Tamago]: https://github.com/usbarmory/tamago
+	TamagoVersion string `json:"tamago_version"`
+}

--- a/api/log_entries.go
+++ b/api/log_entries.go
@@ -30,7 +30,7 @@ type FirmwareRelease struct {
 	Component string `json:"component"`
 
 	// TagName identifies the version of this release, e.g. "0.1.2"
-	TagName string `json:"tag_name"`
+	TagName string `json:"git_tag_name"`
 
 	// CommitHash contains the hex-encoded SHA-1 commit hash of the git repository when checked
 	// out at TagName. Committing to this information allows verifiers that cannot
@@ -41,13 +41,13 @@ type FirmwareRelease struct {
 	//  - if the CommitHash is the same, then they have the same code checked out but
 	//    there is a problem with the build toolchain (different tooling or non-reproducible
 	//    builds).
-	CommitHash string `json:"commit_sha"`
+	CommitHash string `json:"git_commit_sha"`
 
 	// Sha256Digest is the hash of the compiled firmware binary. Believers that are
 	// installing a firmware release must check that the firmware data they are going to
 	// believe has a fingerprint matching this hash. Verifiers that check out the correct
 	// source repo & version must be able to reproducibly build a binary that has this fingerprint.
-	Sha256Digest []byte `json:"sha256_digest"`
+	Sha256Digest []byte `json:"firmware_digest_sha256"`
 
 	// TamagoVersion identifies the version of [Tamago] that the builder used to compile
 	// the binary with Sha256Digest.

--- a/api/log_entries.go
+++ b/api/log_entries.go
@@ -32,7 +32,7 @@ type FirmwareRelease struct {
 	// TagName identifies the version of this release, e.g. "0.1.2"
 	TagName string `json:"tag_name"`
 
-	// CommitHash contains the SHA256 commit hash of the git repository when checked
+	// CommitHash contains the hex-encoded SHA-1 commit hash of the git repository when checked
 	// out at TagName. Committing to this information allows verifiers that cannot
 	// reproduce a build to quickly narrow down the problem space:
 	//  - if this CommitHash is different then they have checked out different code
@@ -41,7 +41,7 @@ type FirmwareRelease struct {
 	//  - if the CommitHash is the same, then they have the same code checked out but
 	//    there is a problem with the build toolchain (different tooling or non-reproducible
 	//    builds).
-	CommitHash []byte `json:"commit_sha"`
+	CommitHash string `json:"commit_sha"`
 
 	// Sha256Digest is the hash of the compiled firmware binary. Believers that are
 	// installing a firmware release must check that the firmware data they are going to

--- a/api/log_entries.go
+++ b/api/log_entries.go
@@ -29,28 +29,28 @@ type FirmwareRelease struct {
 	// build.
 	Component string `json:"component"`
 
-	// TagName identifies the version of this release, e.g. "0.1.2"
-	TagName string `json:"git_tag_name"`
+	// GitTagName identifies the version of this release, e.g. "0.1.2"
+	GitTagName string `json:"git_tag_name"`
 
-	// CommitHash contains the hex-encoded SHA-1 commit hash of the git repository when checked
+	// GitCommitFingerprint contains the hex-encoded SHA-1 commit hash of the git repository when checked
 	// out at TagName. Committing to this information allows verifiers that cannot
 	// reproduce a build to quickly narrow down the problem space:
-	//  - if this CommitHash is different then they have checked out different code
+	//  - if this GitCommitFingerprint is different then they have checked out different code
 	//    than was used to build the binary. This could happen if the wrong repo was
 	//    used, or because the TagName was changed to a different commit
-	//  - if the CommitHash is the same, then they have the same code checked out but
+	//  - if the GitCommitFingerprint is the same, then they have the same code checked out but
 	//    there is a problem with the build toolchain (different tooling or non-reproducible
 	//    builds).
-	CommitHash string `json:"git_commit_sha"`
+	GitCommitFingerprint string `json:"git_commit_fingerprint"`
 
-	// Sha256Digest is the hash of the compiled firmware binary. Believers that are
+	// FirmwareDigestSha256 is the hash of the compiled firmware binary. Believers that are
 	// installing a firmware release must check that the firmware data they are going to
 	// believe has a fingerprint matching this hash. Verifiers that check out the correct
 	// source repo & version must be able to reproducibly build a binary that has this fingerprint.
-	Sha256Digest []byte `json:"firmware_digest_sha256"`
+	FirmwareDigestSha256 []byte `json:"firmware_digest_sha256"`
 
 	// TamagoVersion identifies the version of [Tamago] that the builder used to compile
-	// the binary with Sha256Digest.
+	// the binary with FirmwareDigestSha256.
 	//
 	// [Tamago]: https://github.com/usbarmory/tamago
 	TamagoVersion string `json:"tamago_version"`

--- a/api/log_entries_test.go
+++ b/api/log_entries_test.go
@@ -40,7 +40,7 @@ func TestParseFirmwareRelease(t *testing.T) {
 	if got, want := r.TagName, "0.1.2"; got != want {
 		t.Errorf("Got %q, want %q", got, want)
 	}
-	if got, want := r.CommitHash, mustDecode("aac1e176cfac1a1e079b5f624b83fda54b5d0f76"); !bytes.Equal(got, want) {
+	if got, want := r.CommitHash, "aac1e176cfac1a1e079b5f624b83fda54b5d0f76"; got != want {
 		t.Errorf("Got %x, want %x", got, want)
 	}
 	if got, want := r.Sha256Digest, mustDecode("f25e136aba0fb12abecf01be5cc3d9c3e11da54a171f4213e1c28cd91985c8d1"); !bytes.Equal(got, want) {

--- a/api/log_entries_test.go
+++ b/api/log_entries_test.go
@@ -1,0 +1,60 @@
+// Copyright 2023 The Armored Witness Applet authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/transparency-dev/armored-witness-applet/api"
+)
+
+func TestParseFirmwareRelease(t *testing.T) {
+	bs, err := os.ReadFile("example_firmware_release.json")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	r := api.FirmwareRelease{}
+	if err := json.Unmarshal(bs, &r); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got, want := r.Component, api.ComponentApplet; got != want {
+		t.Errorf("Got %q, want %q", got, want)
+	}
+	if got, want := r.TagName, "0.1.2"; got != want {
+		t.Errorf("Got %q, want %q", got, want)
+	}
+	if got, want := r.CommitHash, mustDecode("aac1e176cfac1a1e079b5f624b83fda54b5d0f76"); !bytes.Equal(got, want) {
+		t.Errorf("Got %x, want %x", got, want)
+	}
+	if got, want := r.Sha256Digest, mustDecode("f25e136aba0fb12abecf01be5cc3d9c3e11da54a171f4213e1c28cd91985c8d1"); !bytes.Equal(got, want) {
+		t.Errorf("Got %x, want %x", got, want)
+	}
+	if got, want := r.TamagoVersion, "1.20.6"; got != want {
+		t.Errorf("Got %q, want %q", got, want)
+	}
+}
+
+func mustDecode(in string) []byte {
+	r, err := base64.StdEncoding.DecodeString(in)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}

--- a/api/log_entries_test.go
+++ b/api/log_entries_test.go
@@ -37,19 +37,19 @@ func TestParseFirmwareRelease(t *testing.T) {
 	if got, want := r.Component, api.ComponentApplet; got != want {
 		t.Errorf("Got %q, want %q", got, want)
 	}
-	if got, want := r.TagName, "0.1.2"; got != want {
+	if got, want := r.GitTagName, "0.1.2"; got != want {
 		t.Errorf("Got %q, want %q", got, want)
 	}
-	if got, want := len(r.CommitHash), 40; got != want {
+	if got, want := len(r.GitCommitFingerprint), 40; got != want {
 		t.Errorf("Got %d, want %d", got, want)
 	}
-	if got, want := r.CommitHash, "aac1e176cfac1a1e079b5f624b83fda54b5d0f76"; got != want {
+	if got, want := r.GitCommitFingerprint, "aac1e176cfac1a1e079b5f624b83fda54b5d0f76"; got != want {
 		t.Errorf("Got %x, want %x", got, want)
 	}
-	if got, want := len(r.Sha256Digest), 32; got != want {
+	if got, want := len(r.FirmwareDigestSha256), 32; got != want {
 		t.Errorf("Got %d, want %d", got, want)
 	}
-	if got, want := r.Sha256Digest, mustDecode("8l4TaroPsSq+zwG+XMPZw+EdpUoXH0IT4cKM2RmFyNE="); !bytes.Equal(got, want) {
+	if got, want := r.FirmwareDigestSha256, mustDecode("8l4TaroPsSq+zwG+XMPZw+EdpUoXH0IT4cKM2RmFyNE="); !bytes.Equal(got, want) {
 		t.Errorf("Got %x, want %x", got, want)
 	}
 	if got, want := r.TamagoVersion, "1.20.6"; got != want {

--- a/api/log_entries_test.go
+++ b/api/log_entries_test.go
@@ -40,10 +40,16 @@ func TestParseFirmwareRelease(t *testing.T) {
 	if got, want := r.TagName, "0.1.2"; got != want {
 		t.Errorf("Got %q, want %q", got, want)
 	}
+	if got, want := len(r.CommitHash), 40; got != want {
+		t.Errorf("Got %d, want %d", got, want)
+	}
 	if got, want := r.CommitHash, "aac1e176cfac1a1e079b5f624b83fda54b5d0f76"; got != want {
 		t.Errorf("Got %x, want %x", got, want)
 	}
-	if got, want := r.Sha256Digest, mustDecode("f25e136aba0fb12abecf01be5cc3d9c3e11da54a171f4213e1c28cd91985c8d1"); !bytes.Equal(got, want) {
+	if got, want := len(r.Sha256Digest), 32; got != want {
+		t.Errorf("Got %d, want %d", got, want)
+	}
+	if got, want := r.Sha256Digest, mustDecode("8l4TaroPsSq+zwG+XMPZw+EdpUoXH0IT4cKM2RmFyNE="); !bytes.Equal(got, want) {
 		t.Errorf("Got %x, want %x", got, want)
 	}
 	if got, want := r.TamagoVersion, "1.20.6"; got != want {


### PR DESCRIPTION
This is used as the leaf in the binary transparency log. This is the other side of PR #69.