### PR TITLE
Update witness journal location

### DIFF
--- a/trusted_applet/main.go
+++ b/trusted_applet/main.go
@@ -50,18 +50,19 @@ import (
 )
 
 const (
-	// slotsPartitionOffsetBytes defines where our witness data storage partition starts.
+	// slotsPartitionStartBlock defines where our witness data storage partition starts.
 	// Changing this location is overwhelmingly likely to result in data loss.
-	slotsPartitionOffsetBytes = 1 << 30
-	// slotsPartitionLengthBytes specifies the size of the slots partition.
+	slotsPartitionStartBlock = 0x400000
+	// slotsPartitionLengthBlocks specifies the size of the slots partition.
 	// Increasing this value is relatively safe, if you're sure there is no data
 	// stored in blocks which follow the current partition.
 	//
-	// We're starting with enough space for 1024 slots of 1MB each.
-	slotsPartitionLengthBytes = 1024 * slotSizeBytes
+	// We're starting with enough space for 4096 slots of 512KB each, which should be plenty.
+	slotsPartitionLengthBlocks = 0x400000
 
 	// slotSizeBytes is the size of each individual slot in the partition.
-	slotSizeBytes = 1 << 20
+	// Changing this is overwhelmingly likely to result in data loss.
+	slotSizeBytes = 512 << 10
 )
 
 var (
@@ -315,8 +316,8 @@ func openStorage() *slots.Partition {
 	dev := &storage.Device{CardInfo: &info}
 	bs := dev.BlockSize()
 	geo := slots.Geometry{
-		Start:  slotsPartitionOffsetBytes / bs,
-		Length: slotsPartitionLengthBytes / bs,
+		Start:  slotsPartitionStartBlock,
+		Length: slotsPartitionLengthBlocks,
 	}
 	sl := slotSizeBytes / bs
 	for i := uint(0); i < geo.Length; i += sl {


### PR DESCRIPTION
This updates the on-MMC location of the witness' journal.

Also switch to a block-centric view to make it easier to reason about.