### PR TITLE
Clarify reboot semantics

### DIFF
--- a/trusted_applet/internal/update/mock_update_test.go
+++ b/trusted_applet/internal/update/mock_update_test.go
@@ -78,18 +78,6 @@ func (mr *MockLocalMockRecorder) InstallOS(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallOS", reflect.TypeOf((*MockLocal)(nil).InstallOS), arg0)
 }
 
-// Reboot mocks base method.
-func (m *MockLocal) Reboot() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Reboot")
-}
-
-// Reboot indicates an expected call of Reboot.
-func (mr *MockLocalMockRecorder) Reboot() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reboot", reflect.TypeOf((*MockLocal)(nil).Reboot))
-}
-
 // MockRemote is a mock of Remote interface.
 type MockRemote struct {
 	ctrl     *gomock.Controller

--- a/trusted_applet/internal/update/update.go
+++ b/trusted_applet/internal/update/update.go
@@ -34,14 +34,12 @@ type Local interface {
 	GetInstalledVersions() (os, applet semver.Version, err error)
 
 	// InstallOS updates the OS to the version contained in the firmware bundle.
+	// If the update is successful, the RPC will not return.
 	InstallOS(firmware.Bundle) error
 
 	// InstallApplet updates the Applet to the version contained in the firmware bundle.
+	// If the update is successful, the RPC will not return.
 	InstallApplet(firmware.Bundle) error
-
-	// Reboot instructs the device to reboot after new firmware is installed.
-	// This call will not return and deferred functions will not be run.
-	Reboot()
 }
 
 // A Remote represents the connection to the Internet and allows access to
@@ -110,8 +108,6 @@ func (u Updater) Update(ctx context.Context) error {
 		if err := u.local.InstallOS(bundle); err != nil {
 			return fmt.Errorf("failed to install OS firmware: %v", err)
 		}
-		// Defer rebooting until we've attempted updating the Applet
-		defer u.local.Reboot()
 	}
 	if u.appVer.LessThan(appVer) {
 		glog.Infof("Upgrading applet from %q to %q", u.osVer, osVer)
@@ -125,7 +121,6 @@ func (u Updater) Update(ctx context.Context) error {
 		if err := u.local.InstallApplet(bundle); err != nil {
 			return fmt.Errorf("failed to install applet firmware: %v", err)
 		}
-		u.local.Reboot()
 	}
 	return nil
 }

--- a/trusted_applet/internal/update/update_test.go
+++ b/trusted_applet/internal/update/update_test.go
@@ -35,7 +35,6 @@ func TestUpdate(t *testing.T) {
 		remoteOS       semver.Version
 		wantOSInstall  bool
 		wantAppInstall bool
-		wantReboot     bool
 	}{
 		{
 			desc:           "No changes",
@@ -45,7 +44,6 @@ func TestUpdate(t *testing.T) {
 			remoteApp:      *semver.New("1.0.2"),
 			wantOSInstall:  false,
 			wantAppInstall: false,
-			wantReboot:     false,
 		},
 		{
 			desc:           "OS update",
@@ -55,7 +53,6 @@ func TestUpdate(t *testing.T) {
 			remoteApp:      *semver.New("1.0.2"),
 			wantOSInstall:  true,
 			wantAppInstall: false,
-			wantReboot:     true,
 		},
 		{
 			desc:           "Applet update",
@@ -65,7 +62,6 @@ func TestUpdate(t *testing.T) {
 			remoteApp:      *semver.New("1.0.4"),
 			wantOSInstall:  false,
 			wantAppInstall: true,
-			wantReboot:     true,
 		},
 		{
 			desc:           "Both update",
@@ -74,8 +70,7 @@ func TestUpdate(t *testing.T) {
 			remoteOS:       *semver.New("1.0.3"),
 			remoteApp:      *semver.New("1.0.4"),
 			wantOSInstall:  true,
-			wantAppInstall: true,
-			wantReboot:     true,
+			wantAppInstall: true, // In reality this won't happen because OS install will cause reboot
 		},
 		{
 			desc:           "Downgrade",
@@ -85,7 +80,6 @@ func TestUpdate(t *testing.T) {
 			remoteApp:      *semver.New("1.0.2"),
 			wantOSInstall:  false,
 			wantAppInstall: false,
-			wantReboot:     false,
 		},
 	}
 	for _, tC := range testCases {
@@ -116,11 +110,6 @@ func TestUpdate(t *testing.T) {
 				remote.EXPECT().GetApplet().Return(appDownload, nil)
 				verifier.EXPECT().Verify(gomock.Eq(appDownload)).Return(nil)
 				local.EXPECT().InstallApplet(gomock.Eq(appDownload)).Return(nil)
-			}
-			if tC.wantReboot {
-				// Allow this to be called multiple times, even though in reality the
-				// implementation would not get to the second invocation.
-				local.EXPECT().Reboot().MinTimes(1)
 			}
 
 			if err := updater.Update(ctx); err != nil {


### PR DESCRIPTION
Reboot is now performed immediately on successful OS/Applet install and the separate call to Reboot is no longer required.
