### PR TITLE
Add makefile targets for managing local dev FT log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.21-alpine3.17@sha256:ecaab0e81d070800a399d2e805f0fcc22806e130166a2
 ARG TAMAGO_VERSION
 
 # Install dependencies.
-RUN apk update && apk add bash make wget
+RUN apk update && apk add bash git make wget
 
 RUN wget "https://github.com/usbarmory/tamago-go/releases/download/tamago-go${TAMAGO_VERSION}/tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz"
 RUN tar -xvf "tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz" -C /
@@ -15,4 +15,4 @@ COPY . .
 # Set Tamago path for Make rule.
 ENV TAMAGO=/usr/local/tamago-go/bin/go
 
-RUN make elf
+RUN make trusted_applet_nosign

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM amd64/ubuntu:latest
+FROM golang:1.21-alpine3.17@sha256:ecaab0e81d070800a399d2e805f0fcc22806e130166a2f880456abeb04e401b0
 
 ARG TAMAGO_VERSION
 
 # Install dependencies.
-RUN apt-get update && apt-get install -y make
-RUN apt-get install -y wget
+RUN apk update && apk add bash make wget
 
 RUN wget "https://github.com/usbarmory/tamago-go/releases/download/tamago-go${TAMAGO_VERSION}/tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz"
 RUN tar -xvf "tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz" -C /

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BUILD = ${BUILD_USER}@${BUILD_HOST} on ${BUILD_DATE}
 REV = $(shell git rev-parse --short HEAD 2> /dev/null)
 DEV_LOG_DIR ?= ./bin/log
 DEV_LOG_ORIGIN ?= "DEV.armoredwitness.transparency.dev/${USER}"
-GIT_SEMVER_TAG ?= $(shell (git describe --tags --exact-match --match 'v*.*.*' 2>/dev/null || git describe --match 'v*.*.*' --tags 2>/dev/null || git describe --tags 2>/dev/null || echo -n 'v0.0.0-'`git rev-parse HEAD`) | tail --bytes=+2 )
+GIT_SEMVER_TAG ?= $(shell (git describe --tags --exact-match --match 'v*.*.*' 2>/dev/null || git describe --match 'v*.*.*' --tags 2>/dev/null || git describe --tags 2>/dev/null || echo -n 'v0.0.0-'`git rev-parse HEAD`) | tail -c +2 )
 
 SHELL = /bin/bash
 

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,11 @@ GOFLAGS = -tags ${BUILD_TAGS} -trimpath \
 
 all: trusted_applet
 
-trusted_applet: APP=trusted_applet
-trusted_applet: DIR=$(CURDIR)/trusted_applet
-trusted_applet: check_applet_env elf manifest
+trusted_applet_nosign: APP=trusted_applet
+trusted_applet_nosign: DIR=$(CURDIR)/trusted_applet
+trusted_applet_nosign: elf manifest
+
+trusted_applet: check_signing_env trusted_applet_nosign 
 	echo "signing Trusted Applet"
 	@if [ "${SIGN_PWD}" != "" ]; then \
 		echo -e "${SIGN_PWD}\n" | ${SIGN} -S -s ${APPLET_PRIVATE_KEY} -m ${CURDIR}/bin/trusted_applet.elf -x ${CURDIR}/bin/trusted_applet.sig; \
@@ -126,7 +128,7 @@ $(APP).dcd: dcd
 
 #### utilities ####
 
-check_applet_env:
+check_signing_env:
 	@if [ "${APPLET_PRIVATE_KEY}" == "" ] || [ ! -f "${APPLET_PRIVATE_KEY}" ]; then \
 		echo 'You need to set the APPLET_PRIVATE_KEY variable to a valid signing key path'; \
 		exit 1; \


### PR DESCRIPTION
This PR:
  - Adds support for managing a local serverless log instance for local testing.
  - Creates a manifest file whenever the applet is built

To use the log, append a `log_applet` target to the make invocation, e.g.:

```
make trusted_applet log_applet
```

Note that `LOG_PUBLIC_KEY` and `LOG_PRIVATE_KEY` env variables are expected to be set to paths to key files, in keeping with the other key-related env vars.