### PR TITLE
Fix typo

### DIFF
--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -136,5 +136,5 @@ substitutions:
   _KMS_KEY_VERSION: '1'
   # Log-related.
   _ENTRIES_DIR: firmware-log-sequence
-  _ORIGIN: transparency.dev/armored-witness/fireware_transparency/ci/0
+  _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/0
   _LOG_NAME: firmware-log-ci


### PR DESCRIPTION
`fireware` -> `firmware`