### PR TITLE
Bump manifest tool and add firmware_type flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ trusted_applet: check_signing_env trusted_applet_nosign
 log_initialise:
 	echo "(Re-)initialising log at ${DEV_LOG_DIR}"
 	@rm -fr ${DEV_LOG_DIR}
-	go run github.com/transparency-dev/serverless-log/cmd/integrate@HEAD \
+	go run github.com/transparency-dev/serverless-log/cmd/integrate@a56a93b5681e5dc231882ac9de435c21cb340846 \
 		--storage_dir=${DEV_LOG_DIR} \
 		--origin=${DEV_LOG_ORIGIN} \
 		--private_key=${LOG_PRIVATE_KEY} \
@@ -89,12 +89,12 @@ log_applet:
 	@if [ ! -f ${DEV_LOG_DIR}/checkpoint ]; then \
 		make log_initialise; \
 	fi
-	go run github.com/transparency-dev/serverless-log/cmd/sequence@HEAD \
+	go run github.com/transparency-dev/serverless-log/cmd/integrate@a56a93b5681e5dc231882ac9de435c21cb340846 \
 		--storage_dir=${DEV_LOG_DIR} \
 		--origin=${DEV_LOG_ORIGIN} \
 		--public_key=${LOG_PUBLIC_KEY} \
 		--entries=${CURDIR}/bin/trusted_applet_manifest.json
-	-go run github.com/transparency-dev/serverless-log/cmd/integrate@HEAD \
+	-go run github.com/transparency-dev/serverless-log/cmd/integrate@a56a93b5681e5dc231882ac9de435c21cb340846 \
 		--storage_dir=${DEV_LOG_DIR} \
 		--origin=${DEV_LOG_ORIGIN} \
 		--private_key=${LOG_PRIVATE_KEY} \
@@ -156,10 +156,11 @@ $(APP).elf: check_tamago
 $(APP)_manifest.json: TAMAGO_SEMVER=$(shell ${TAMAGO} version | sed 's/.*go\([0-9]\.[0-9]*\.[0-9]*\).*/\1/')
 $(APP)_manifest.json:
 	# Create manifest
-	go run ./release/json_constructor/json_constructor.go \
+	go run github.com/transparency-dev/armored-witness/cmd/manifest@e852dd82d9d56121576aff66de89e800380e5d53 \
 		--git_tag=${GIT_SEMVER_TAG} \
 		--git_commit_fingerprint="${REV}" \
 		--firmware_file=${CURDIR}/bin/$(APP).elf \
+		--firmware_type=TRUSTED_APPLET \
 		--tamago_version=${TAMAGO_SEMVER} > ${CURDIR}/bin/trusted_applet_manifest.json
 	@echo ---------- Manifest --------------
 	@cat ${CURDIR}/bin/trusted_applet_manifest.json

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,9 @@ require (
 	github.com/transparency-dev/formats v0.0.0-20230914071414-5732692f1e50
 	github.com/transparency-dev/merkle v0.0.2
 	github.com/transparency-dev/witness v0.0.0-20230915104643-4681d15a938b
-	github.com/usbarmory/GoTEE v0.0.0-20230828134615-ef53a1a84ba4
+	github.com/usbarmory/GoTEE v0.0.0-20230914094934-f4f769daa5a9
 	github.com/usbarmory/imx-enet v0.0.0-20230622162703-9eec0bcf6bb4
-	github.com/usbarmory/tamago v0.0.0-20230814171810-6cd63c1accf5
+	github.com/usbarmory/tamago v0.0.0-20230922151120-1f76695abebe
 	golang.org/x/crypto v0.13.0
 	golang.org/x/crypto/x509roots/fallback v0.0.0-20230623170555-183630ada7e0
 	golang.org/x/mod v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -80,13 +80,13 @@ github.com/transparency-dev/serverless-log v0.0.0-20230914155322-9b6f31f76f1f h1
 github.com/transparency-dev/serverless-log v0.0.0-20230914155322-9b6f31f76f1f/go.mod h1:wePHXib4JC193IyIQImP3oNXYpUZQWzKcF6BJ8bC8GY=
 github.com/transparency-dev/witness v0.0.0-20230915104643-4681d15a938b h1:wqdCr8Cnus8XV49A60EvM/k++CVTNFfhBLPkid8lzNY=
 github.com/transparency-dev/witness v0.0.0-20230915104643-4681d15a938b/go.mod h1:bLBEbEqDhZnEk34v0kK+Wl7J87/Y3iv1ChW7yKx9Tno=
-github.com/usbarmory/GoTEE v0.0.0-20230828134615-ef53a1a84ba4 h1:fdcx7wzwuQkyo0hR32eJQsW9eb3FAcU874zd1Ji8juM=
-github.com/usbarmory/GoTEE v0.0.0-20230828134615-ef53a1a84ba4/go.mod h1:164CE5Gb+PiM6cxhYpyPg9FlpqttRFwUZ+KiTonK4Ak=
+github.com/usbarmory/GoTEE v0.0.0-20230914094934-f4f769daa5a9 h1:bVjcARGT+mwll/+no7bsCCC1UDldtuNXL00twGtLPGo=
+github.com/usbarmory/GoTEE v0.0.0-20230914094934-f4f769daa5a9/go.mod h1:mPJL62h2iMZwmu2cZ/tvjCyk0uSeq06n1UJBoigN2qY=
 github.com/usbarmory/imx-enet v0.0.0-20230622162703-9eec0bcf6bb4 h1:qdV3sa9B6hXs9W8mNhlpR5AW/VC1La1ytrt5ddHQx34=
 github.com/usbarmory/imx-enet v0.0.0-20230622162703-9eec0bcf6bb4/go.mod h1:T7T/0Fejbnj4y/uIVDcNPT1gnKNMmPsYnnshdWFuz+o=
 github.com/usbarmory/tamago v0.0.0-20220823080407-04f05cf2a5a3/go.mod h1:Lok79mjbJnhoBGqhX5cCUsZtSemsQF5FNZW+2R1dRr8=
-github.com/usbarmory/tamago v0.0.0-20230814171810-6cd63c1accf5 h1:cu+znyiHqWwvmoPM6uplHt+bOkn5hc+133/kwg15ywk=
-github.com/usbarmory/tamago v0.0.0-20230814171810-6cd63c1accf5/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
+github.com/usbarmory/tamago v0.0.0-20230922151120-1f76695abebe h1:h3PrTFE6iPJzyYz+/2iyIPCUS5yyuqPHRCMsW2IXk3k=
+github.com/usbarmory/tamago v0.0.0-20230922151120-1f76695abebe/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
Migrate to new `manifest` tool location, and specify firmware type.

Needs transparency-dev/armored-witness/pull/17