### PR TITLE
Write to a single bucket for the Trusted Applet artifacts.

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -53,13 +53,13 @@ steps:
       - storage
       - cp
       - output/trusted_applet.elf
-      - gs://${_TRUSTED_APPLET_BUCKET}/${TAG_NAME}/trusted_applet.elf
+      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${TAG_NAME}/firmware.elf
   - name: gcr.io/cloud-builders/gcloud
     args:
       - storage
       - cp
       - output/trusted_applet.sig
-      - gs://${_TRUSTED_APPLET_BUCKET}/${TAG_NAME}/trusted_applet.sig
+      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${TAG_NAME}/firmware.sig
   ### Construct log entry / Claimant Model statement.
   - name: golang
     args:
@@ -108,7 +108,8 @@ steps:
       - '{"origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}"}'
 substitutions:
   # Build-related.
-  _TRUSTED_APPLET_BUCKET: trusted-applet-artifacts
+  _FIRMWARE_BUCKET: armored-witness-firmware
+  _FIRMWARE_COMPONENT: trusted-applet
   _TAMAGO_VERSION: '1.20.6'
   # Signing-related.
   _REGION: europe-west2
@@ -118,4 +119,4 @@ substitutions:
   # Log-related.
   _ENTRIES_DIR: firmware-log-sequence
   _ORIGIN: transparency.dev/armored-witness/firmware_transparency/prod/0
-  _LOG_NAME: firmware-log
+  _LOG_NAME: armored-witness-firmware-log

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -53,13 +53,13 @@ steps:
       - storage
       - cp
       - output/trusted_applet.elf
-      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${TAG_NAME}/firmware.elf
+      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${TAG_NAME}/trusted_applet.elf
   - name: gcr.io/cloud-builders/gcloud
     args:
       - storage
       - cp
       - output/trusted_applet.sig
-      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${TAG_NAME}/firmware.sig
+      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${TAG_NAME}/trusted_applet_transparency_dev.sig
   ### Construct log entry / Claimant Model statement.
   - name: golang
     args:

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -54,13 +54,13 @@ steps:
       - storage
       - cp
       - output/trusted_applet.elf
-      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${_TEST_TAG_NAME}/firmware.elf
+      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${_TEST_TAG_NAME}/trusted_applet.elf
   - name: gcr.io/cloud-builders/gcloud
     args:
       - storage
       - cp
       - output/trusted_applet.sig
-      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${_TEST_TAG_NAME}/firmware.sig
+      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${_TEST_TAG_NAME}/trusted_applet_transparency_dev.sig
   ### Construct log entry / Claimant Model statement.
   - name: golang
     args:

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -28,6 +28,7 @@ steps:
     args:
       - ls
       - output
+  ### TODO(jayhou): replace this with the signing tool in the apex repo.
   # Sign the built applet.
   - name: gcr.io/cloud-builders/gcloud
     args:
@@ -53,13 +54,13 @@ steps:
       - storage
       - cp
       - output/trusted_applet.elf
-      - gs://${_TRUSTED_APPLET_BUCKET}/${_TEST_TAG_NAME}/trusted_applet.elf
+      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${_TEST_TAG_NAME}/firmware.elf
   - name: gcr.io/cloud-builders/gcloud
     args:
       - storage
       - cp
       - output/trusted_applet.sig
-      - gs://${_TRUSTED_APPLET_BUCKET}/${_TEST_TAG_NAME}/trusted_applet.sig
+      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${_TEST_TAG_NAME}/firmware.sig
   ### Construct log entry / Claimant Model statement.
   - name: golang
     args:
@@ -89,7 +90,7 @@ steps:
       - storage
       - cp
       - output/trusted_applet_manifest.json
-      - 'gs://${_LOG_NAME}/${_ENTRIES_DIR}/trusted_applet_manifest.json'
+      - gs://${_LOG_NAME}/${_ENTRIES_DIR}/trusted_applet_manifest.json
   # Sequence log entry.
   - name: gcr.io/cloud-builders/gcloud
     args:
@@ -108,7 +109,8 @@ steps:
       - '{"origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}"}'
 substitutions:
   # Build-related.
-  _TRUSTED_APPLET_BUCKET: trusted-applet-artifacts-ci
+  _FIRMWARE_BUCKET: armored-witness-firmware-ci
+  _FIRMWARE_COMPONENT: trusted-applet
   _TAMAGO_VERSION: '1.20.6'
   _TEST_TAG_NAME: '0.1.2'
   # Signing-related.
@@ -119,4 +121,4 @@ substitutions:
   # Log-related.
   _ENTRIES_DIR: firmware-log-sequence
   _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/0
-  _LOG_NAME: firmware-log-ci
+  _LOG_NAME: armored-witness-firmware-log-ci


### PR DESCRIPTION
Naming layout will look like:

* `armored-witness-firmware[-ci]/[trusted-applet, trusted-os, boot, recovery]/<tag_name>/elf, manifest`
* `armored-witness-firmware-log[-ci]/...`

Tested cloudbuild_ci.yaml on the `dev-trigger` in our project.