### PR TITLE
Store firmware binaries in CAS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,8 @@ log_initialise:
 
 ## log_applet adds the trusted_applet_manifest file created during the build to the dev FT log.
 log_applet: LOG_STORAGE_DIR=$(DEV_LOG_DIR)/log
-log_applet: LOG_ARTEFACT_DIR=$(DEV_LOG_DIR)/trusted-applet/$(GIT_SEMVER_TAG)
+log_applet: LOG_ARTEFACT_DIR=$(DEV_LOG_DIR)
+log_applet: ARTEFACT_HASH=$(shell sha256sum ${CURDIR}/bin/trusted_applet.elf | cut -f1 -d" ")
 log_applet:
 	@if [ "${LOG_PRIVATE_KEY}" == "" -o "${LOG_PUBLIC_KEY}" == "" ]; then \
 		@echo "You need to set LOG_PRIVATE_KEY and LOG_PUBLIC_KEY variables"; \
@@ -112,7 +113,7 @@ log_applet:
 		--private_key=${LOG_PRIVATE_KEY} \
 		--public_key=${LOG_PUBLIC_KEY}
 	@mkdir -p ${LOG_ARTEFACT_DIR}
-	cp ${CURDIR}/bin/trusted_applet.* ${LOG_ARTEFACT_DIR}
+	cp ${CURDIR}/bin/trusted_applet.elf ${LOG_ARTEFACT_DIR}/${ARTEFACT_HASH}
 
 #### ARM targets ####
 

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ log_initialise:
 
 ## log_applet adds the trusted_applet_manifest file created during the build to the dev FT log.
 log_applet: LOG_STORAGE_DIR=$(DEV_LOG_DIR)/log
-log_applet: LOG_ARTEFACT_DIR=$(DEV_LOG_DIR)
+log_applet: LOG_ARTEFACT_DIR=$(DEV_LOG_DIR)/artefacts
 log_applet: ARTEFACT_HASH=$(shell sha256sum ${CURDIR}/bin/trusted_applet.elf | cut -f1 -d" ")
 log_applet:
 	@if [ "${LOG_PRIVATE_KEY}" == "" -o "${LOG_PUBLIC_KEY}" == "" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BUILD = ${BUILD_USER}@${BUILD_HOST} on ${BUILD_DATE}
 REV = $(shell git rev-parse --short HEAD 2> /dev/null)
 DEV_LOG_ORIGIN ?= "DEV.armoredwitness.transparency.dev/${USER}"
 GIT_SEMVER_TAG ?= $(shell (git describe --tags --exact-match --match 'v*.*.*' 2>/dev/null || git describe --match 'v*.*.*' --tags 2>/dev/null || git describe --tags 2>/dev/null || echo -n v0.0.${BUILD_EPOCH}+`git rev-parse HEAD`) | tail -c +2 )
-FT_BIN_URL ?= "http://$(shell hostname --fqdn):9944/"
+FT_BIN_URL ?= "http://$(shell hostname --fqdn):9944/artefacts/"
 FT_LOG_URL ?= "http://$(shell hostname --fqdn):9944/log/"
 FT_LOG_ORIGIN ?= $(DEV_LOG_ORIGIN)
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/machinebox/progress v0.2.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7
-	github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d
+	github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27
 	github.com/transparency-dev/armored-witness-os v0.0.0-20230904142303-8cff7e12c215
 	github.com/transparency-dev/formats v0.0.0-20230920083814-0f75b1d4e813
 	github.com/transparency-dev/merkle v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,6 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7 h1:3xrmiN4hwWi3nxvDo9asUWrNCjaPYBhF+rHpW97Fde0=
 github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7/go.mod h1:GTj2zM9nwFe7G7gaXzIbkKJ/PkZfvVq4TdNiA6CBsdo=
-github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d h1:76yBTOSuqGXpKe7qjF1Yjzf4MOhXYryeVObzUkpKHf0=
-github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27 h1:p8mmHwCvTYbuB52ph9knjwWkQmGNZ+3BZJgsw9xIQq0=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/armored-witness-os v0.0.0-20230904142303-8cff7e12c215 h1:xY5bolI/XmV9sBStzn8rSXV8E4foG0pGZAaYUKdrGHc=

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c766
 github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7/go.mod h1:GTj2zM9nwFe7G7gaXzIbkKJ/PkZfvVq4TdNiA6CBsdo=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d h1:76yBTOSuqGXpKe7qjF1Yjzf4MOhXYryeVObzUkpKHf0=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
+github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27 h1:p8mmHwCvTYbuB52ph9knjwWkQmGNZ+3BZJgsw9xIQq0=
+github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/armored-witness-os v0.0.0-20230904142303-8cff7e12c215 h1:xY5bolI/XmV9sBStzn8rSXV8E4foG0pGZAaYUKdrGHc=
 github.com/transparency-dev/armored-witness-os v0.0.0-20230904142303-8cff7e12c215/go.mod h1:WfH1eII946tTqjniWgozuWbJthgDEuSaeGE5jta+3Ew=
 github.com/transparency-dev/formats v0.0.0-20230920083814-0f75b1d4e813 h1:PHklaeYyhPsbhWt+MnKpBvJrsJGkPEaU1JutMj4wNqM=

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -36,11 +36,13 @@ steps:
       - output
   # Copy the artifacts from the Cloud Build VM to GCS.
   - name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
     args:
+      - gcloud
       - storage
       - cp
       - output/trusted_applet.elf
-      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${TAG_NAME}/trusted_applet.elf
+      - gs://${_FIRMWARE_BUCKET}/$(sha256sum output/trusted_applet.elf | cut -f1 -d" ")
   ### Construct log entry / Claimant Model statement.
   - name: golang
     args:

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -113,11 +113,6 @@ substitutions:
   _FIRMWARE_COMPONENT: trusted-applet
   _TAMAGO_VERSION: '1.20.6'
   _TEST_TAG_NAME: '0.1.2'
-  # Signing-related.
-  _REGION: global
-  _KMS_APPLET_KEY: trusted-applet-ci
-  _KMS_APPLET_KEY_VERSION: '1'
-  _KMS_KEYRING: firmware-release-ci
   # Log-related.
   _ENTRIES_DIR: firmware-log-sequence
   _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/0

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -83,13 +83,6 @@ steps:
     args:
       - cat
       - output/trusted_applet_manifest
-  ### Copy the signed manifest to the public artifacts bucket.
-  - name: gcr.io/cloud-builders/gcloud
-    args:
-      - storage
-      - cp
-      - output/trusted_applet_manifest
-      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${_TEST_TAG_NAME}/trusted_applet_manifest
   ### Write the firmware release to the transparency log.
   # Copy the log entry to the sequence bucket, preparing to write to log.
   - name: gcr.io/cloud-builders/gcloud

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -36,11 +36,13 @@ steps:
       - output
   # Copy the artifacts from the Cloud Build VM to GCS.
   - name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
     args:
+      - gcloud
       - storage
       - cp
       - output/trusted_applet.elf
-      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${_TEST_TAG_NAME}/trusted_applet.elf
+      - gs://${_FIRMWARE_BUCKET}/$(sha256sum output/trusted_applet.elf | cut -f1 -d" ")
   ### Construct log entry / Claimant Model statement.
   - name: golang
     args:


### PR DESCRIPTION
This PR updates the Makefile and cloudbuild configs to store the applet firmware binary in the correct CAS location.

See https://github.com/transparency-dev/armored-witness-common/pull/15