### PR TITLE
Bump to TamaGo v1.21.3

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   build:
     env:
-      TAMAGO_VERSION: 1.20.6
+      TAMAGO_VERSION: 1.21.3
       TAMAGO: /usr/local/tamago-go/bin/go
       APPLET_PRIVATE_KEY: /tmp/applet.sec
       APPLET_PUBLIC_KEY: /tmp/applet.pub

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ FT_LOG_URL ?= "http://$(shell hostname --fqdn):9944/log/"
 FT_LOG_ORIGIN ?= $(DEV_LOG_ORIGIN)
 REST_DISTRIBUTOR_BASE_URL ?= "https://api.transparency.dev"
 
+TAMAGO_SEMVER = $(shell [ -n "${TAMAGO}" -a -x "${TAMAGO}" ] && ${TAMAGO} version | sed 's/.*go\([0-9]\.[0-9]*\.[0-9]*\).*/\1/')
+MINIMUM_TAMAGO_VERSION=1.21.3
 
 SHELL = /bin/bash
 
@@ -156,6 +158,10 @@ check_tamago:
 		echo 'You need to set the TAMAGO variable to a compiled version of https://github.com/usbarmory/tamago-go'; \
 		exit 1; \
 	fi
+	@if [ "$(shell printf '%s\n' ${MINIMUM_TAMAGO_VERSION} ${TAMAGO_SEMVER} | sort -V | head -n1 )" != "${MINIMUM_TAMAGO_VERSION}" ]; then \
+		echo "You need TamaGo >= ${MINIMUM_TAMAGO_VERSION}, found ${TAMAGO_SEMVER}" ; \
+		exit 1; \
+	fi
 
 dcd:
 	cp -f $(GOMODCACHE)/$(TAMAGO_PKG)/board/usbarmory/mk2/imximage.cfg $(CURDIR)/bin/$(APP).dcd
@@ -169,7 +175,6 @@ $(APP).elf: check_tamago
 	cd $(DIR) && $(GOENV) $(TAMAGO) build -tags ${BUILD_TAGS} $(GOFLAGS) -o $(CURDIR)/bin/$(APP).elf
 
 
-$(APP)_manifest: TAMAGO_SEMVER=$(shell ${TAMAGO} version | sed 's/.*go\([0-9]\.[0-9]*\.[0-9]*\).*/\1/')
 $(APP)_manifest:
 	# Create manifest
 	@echo ---------- Manifest --------------

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -118,7 +118,7 @@ substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware
   _FIRMWARE_COMPONENT: trusted-applet
-  _TAMAGO_VERSION: '1.20.6'
+  _TAMAGO_VERSION: '1.21.3'
   # Log-related.
   _ENTRIES_DIR: firmware-log-sequence
   _ORIGIN: transparency.dev/armored-witness/firmware_transparency/prod/0

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -116,7 +116,7 @@ substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware-ci
   _FIRMWARE_COMPONENT: trusted-applet
-  _TAMAGO_VERSION: '1.20.6'
+  _TAMAGO_VERSION: '1.21.3'
   _ARMORED_WITNESS_REPO_VERSION: d37d6b19ec4dbd1cad3586ae8ba3ec913829d718
   # Log-related.
   _ENTRIES_DIR: firmware-log-sequence


### PR DESCRIPTION
This PR bumps the version of TamaGo used to build and test to 1.21.3 (required due to recent changes to support BEE), and adds a check to the Makefile to ensure that a TamaGo version at least this new is always used to compile binaries.