### PR TITLE
Use URL that works unauthenticated for the public artifacts

### DIFF
--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -122,8 +122,8 @@ substitutions:
   _ENTRIES_DIR: firmware-log-sequence
   _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/0
   _LOG_NAME: armored-witness-firmware-log-ci
-  _LOG_BASE_URL: https://storage.mtls.cloud.google.com/armored-witness-firmware-log-ci/
-  _BIN_BASE_URL: https://storage.mtls.cloud.google.com/armored-witness-firmware-ci/
+  _LOG_BASE_URL: https://storage.googleapis.com/armored-witness-firmware-log-ci/
+  _BIN_BASE_URL: https://storage.googleapis.com/armored-witness-firmware-ci/
   _LOG_PUBLIC_KEY: transparency.dev-aw-ftlog-ci+f5479c1e+AR6gW0mycDtL17iM2uvQUThJsoiuSRirstEj9a5AdCCu
   _APPLET_PUBLIC_KEY: transparency.dev-aw-applet-ci+3ff32e2c+AV1fgxtByjXuPjPfi0/7qTbEBlPGGCyxqr6ZlppoLOz3
   _OS_PUBLIC_KEY1: transparency.dev-aw-os1-ci+7a0eaef3+AcsqvmrcKIbs21H2Bm2fWb6oFWn/9MmLGNc6NLJty2eQ


### PR DESCRIPTION
Compare:
- curl -i https://storage.googleapis.com/armored-witness-firmware-log-ci/checkpoint
- curl -i https://storage.mtls.cloud.google.com/armored-witness-firmware-log-ci/checkpoint

In addition, I think these URLs should be added to the manifest file. This makes it easy for the verifier to set these build flags, even if they change over time. It also provides assurance that all users are receiving updates from the same logs.
