### PR TITLE
Roll applet logs

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -106,7 +106,7 @@ steps:
       - call
       - sequence
       - --data
-      - '{"entriesDir": "${_ENTRIES_DIR}", "origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}", "kmsKeyName": "ft-log-prod", "kmsKeyRing": "firmware-release-prod", "kmsKeyVersion": 1, "kmsKeyLocation": "global", "noteKeyName": "transparency.dev-aw-ftlog-prod"}'
+      - '{"entriesDir": "${_ENTRIES_DIR}", "origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}", "kmsKeyName": "ft-log-prod", "kmsKeyRing": "firmware-release-prod", "kmsKeyVersion": ${_KEY_VERSION}, "kmsKeyLocation": "global", "noteKeyName": "transparency.dev-aw-ftlog-prod"}'
   # Integrate log entry.
   - name: gcr.io/cloud-builders/gcloud
     args:
@@ -114,7 +114,7 @@ steps:
       - call
       - integrate
       - --data
-      - '{"origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}", "kmsKeyName": "ft-log-prod", "kmsKeyRing": "firmware-release-prod", "kmsKeyVersion": 1, "kmsKeyLocation": "global", "noteKeyName": "transparency.dev-aw-ftlog-prod"}'
+      - '{"origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}", "kmsKeyName": "ft-log-prod", "kmsKeyRing": "firmware-release-prod", "kmsKeyVersion": ${_KEY_VERSION}, "kmsKeyLocation": "global", "noteKeyName": "transparency.dev-aw-ftlog-prod"}'
 substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware
@@ -122,10 +122,12 @@ substitutions:
   _TAMAGO_VERSION: '1.21.3'
   # Log-related.
   _ENTRIES_DIR: firmware-log-sequence
-  _ORIGIN: transparency.dev/armored-witness/firmware_transparency/prod/0
+  # This must correspond with the trailing number on the _FIRMWARE_BUCKET, _ORIGIN, _LOG_NAME values.
+  _KEY_VERSION: 1
+  _ORIGIN: transparency.dev/armored-witness/firmware_transparency/prod/1
   _LOG_NAME: armored-witness-firmware-log
-  _LOG_BASE_URL: https://storage.mtls.cloud.google.com/armored-witness-firmware-log/
-  _BIN_BASE_URL: https://storage.mtls.cloud.google.com/armored-witness-firmware/
+  _LOG_BASE_URL: https://api.transparency.dev/armored-witness-firmware/prod/log/1
+  _BIN_BASE_URL: https://api.transparency.dev/armored-witness-firmware/prod/artefacts/1
   _LOG_PUBLIC_KEY: transparency.dev-aw-ftlog-prod+1d0792e5+Aa3qdhefd2cc/98jV3blslJT2L+iFR8WKHeGcgFmyjnt
   _APPLET_PUBLIC_KEY: transparency.dev-aw-applet-prod+f022187a+AZSnFa8GxH+jHV6ahELk6peqVObbPKrYAdYyMjrzNF35
   _OS_PUBLIC_KEY1: transparency.dev-aw-os-prod+03170554+AV7mmRamQp6VC9CutzSXzqtNhYNyNmQQRcLX07F6qlC1

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -123,7 +123,7 @@ substitutions:
   # Log-related.
   _ENTRIES_DIR: firmware-log-sequence
   # This must correspond with the trailing number on the _FIRMWARE_BUCKET, _ORIGIN, _LOG_NAME values.
-  _KEY_VERSION: 1
+  _KEY_VERSION: '1'
   _ORIGIN: transparency.dev/armored-witness/firmware_transparency/prod/1
   _LOG_NAME: armored-witness-firmware-log
   _LOG_BASE_URL: https://api.transparency.dev/armored-witness-firmware/prod/log/1/

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -126,8 +126,8 @@ substitutions:
   _KEY_VERSION: 1
   _ORIGIN: transparency.dev/armored-witness/firmware_transparency/prod/1
   _LOG_NAME: armored-witness-firmware-log
-  _LOG_BASE_URL: https://api.transparency.dev/armored-witness-firmware/prod/log/1
-  _BIN_BASE_URL: https://api.transparency.dev/armored-witness-firmware/prod/artefacts/1
+  _LOG_BASE_URL: https://api.transparency.dev/armored-witness-firmware/prod/log/1/
+  _BIN_BASE_URL: https://api.transparency.dev/armored-witness-firmware/prod/artefacts/1/
   _LOG_PUBLIC_KEY: transparency.dev-aw-ftlog-prod+1d0792e5+Aa3qdhefd2cc/98jV3blslJT2L+iFR8WKHeGcgFmyjnt
   _APPLET_PUBLIC_KEY: transparency.dev-aw-applet-prod+f022187a+AZSnFa8GxH+jHV6ahELk6peqVObbPKrYAdYyMjrzNF35
   _OS_PUBLIC_KEY1: transparency.dev-aw-os-prod+03170554+AV7mmRamQp6VC9CutzSXzqtNhYNyNmQQRcLX07F6qlC1

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -122,7 +122,7 @@ substitutions:
   # Log-related.
   _ENTRIES_DIR: firmware-log-sequence
   # This must correspond with the trailing number on the _FIRMWARE_BUCKET, _ORIGIN, _LOG_NAME values.
-  _KEY_VERSION: 1
+  _KEY_VERSION: '1'
   _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/1
   _LOG_NAME: armored-witness-firmware-log-ci-1
   _LOG_BASE_URL: https://api.transparency.dev/armored-witness-firmware/ci/log/1/

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -125,8 +125,8 @@ substitutions:
   _KEY_VERSION: 1
   _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/1
   _LOG_NAME: armored-witness-firmware-log-ci-1
-  _LOG_BASE_URL: https://api.transparency.dev/armored-witness-firmware/ci/log/1
-  _BIN_BASE_URL: https://api.transparency.dev/armored-witness-firmware/ci/artefacts/1
+  _LOG_BASE_URL: https://api.transparency.dev/armored-witness-firmware/ci/log/1/
+  _BIN_BASE_URL: https://api.transparency.dev/armored-witness-firmware/ci/artefacts/1/
   _LOG_PUBLIC_KEY: transparency.dev-aw-ftlog-ci+f5479c1e+AR6gW0mycDtL17iM2uvQUThJsoiuSRirstEj9a5AdCCu
   _APPLET_PUBLIC_KEY: transparency.dev-aw-applet-ci+3ff32e2c+AV1fgxtByjXuPjPfi0/7qTbEBlPGGCyxqr6ZlppoLOz3
   _OS_PUBLIC_KEY1: transparency.dev-aw-os1-ci+7a0eaef3+AcsqvmrcKIbs21H2Bm2fWb6oFWn/9MmLGNc6NLJty2eQ

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -104,7 +104,7 @@ steps:
       - call
       - sequence
       - --data
-      - '{"entriesDir": "${_ENTRIES_DIR}", "origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}", "kmsKeyName": "ft-log-ci", "kmsKeyRing": "firmware-release-ci", "kmsKeyVersion": 1, "kmsKeyLocation": "global", "noteKeyName": "transparency.dev-aw-ftlog-ci"}'
+      - '{"entriesDir": "${_ENTRIES_DIR}", "origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}", "kmsKeyName": "ft-log-ci", "kmsKeyRing": "firmware-release-ci", "kmsKeyVersion": ${_KEY_VERSION}, "kmsKeyLocation": "global", "noteKeyName": "transparency.dev-aw-ftlog-ci"}'
   # Integrate log entry.
   - name: gcr.io/cloud-builders/gcloud
     args:
@@ -112,19 +112,21 @@ steps:
       - call
       - integrate
       - --data
-      - '{"origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}", "kmsKeyName": "ft-log-ci", "kmsKeyRing": "firmware-release-ci", "kmsKeyVersion": 1, "kmsKeyLocation": "global", "noteKeyName": "transparency.dev-aw-ftlog-ci"}'
+      - '{"origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}", "kmsKeyName": "ft-log-ci", "kmsKeyRing": "firmware-release-ci", "kmsKeyVersion": ${_KEY_VERSION}, "kmsKeyLocation": "global", "noteKeyName": "transparency.dev-aw-ftlog-ci"}'
 substitutions:
   # Build-related.
-  _FIRMWARE_BUCKET: armored-witness-firmware-ci
+  _FIRMWARE_BUCKET: armored-witness-firmware-ci-1
   _FIRMWARE_COMPONENT: trusted-applet
   _TAMAGO_VERSION: '1.21.3'
   _ARMORED_WITNESS_REPO_VERSION: d37d6b19ec4dbd1cad3586ae8ba3ec913829d718
   # Log-related.
   _ENTRIES_DIR: firmware-log-sequence
-  _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/0
-  _LOG_NAME: armored-witness-firmware-log-ci
-  _LOG_BASE_URL: https://storage.googleapis.com/armored-witness-firmware-log-ci/
-  _BIN_BASE_URL: https://storage.googleapis.com/armored-witness-firmware-ci/
+  # This must correspond with the trailing number on the _FIRMWARE_BUCKET, _ORIGIN, _LOG_NAME values.
+  _KEY_VERSION: 1
+  _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/1
+  _LOG_NAME: armored-witness-firmware-log-ci-1
+  _LOG_BASE_URL: https://api.transparency.dev/armored-witness-firmware/ci/log/1
+  _BIN_BASE_URL: https://api.transparency.dev/armored-witness-firmware/ci/artefacts/1
   _LOG_PUBLIC_KEY: transparency.dev-aw-ftlog-ci+f5479c1e+AR6gW0mycDtL17iM2uvQUThJsoiuSRirstEj9a5AdCCu
   _APPLET_PUBLIC_KEY: transparency.dev-aw-applet-ci+3ff32e2c+AV1fgxtByjXuPjPfi0/7qTbEBlPGGCyxqr6ZlppoLOz3
   _OS_PUBLIC_KEY1: transparency.dev-aw-os1-ci+7a0eaef3+AcsqvmrcKIbs21H2Bm2fWb6oFWn/9MmLGNc6NLJty2eQ


### PR DESCRIPTION
This PR updates GCB configs for the newly rolled CI log.

See also:
- https://github.com/transparency-dev/armored-witness/pull/67
- https://github.com/transparency-dev/armored-witness-os/pull/117