### PR TITLE
Use per Cloud Build trigger unique entriesDir for sequencing.

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -94,24 +94,34 @@ steps:
   ### Write the firmware release to the transparency log.
   # Copy the log entry to the sequence bucket, preparing to write to log.
   #
-  # Use the SHA256 of the manifest as the directory to contain the entry that
-  # this trigger instance is trying to add to the log. This allows multiple
-  # triggers to run without colliding.
+  # Use the SHA256 of the manifest as the name of the manifest. This allows
+  # multiple triggers to run without colliding.
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: bash
     args:
       - -c
       - |
         gcloud storage cp output/trusted_applet_manifest \
-        gs://${_LOG_NAME}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")/trusted_applet_manifest
+        gs://${_LOG_NAME}/${_ENTRIES_DIR}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")
   # Sequence log entry.
   - name: gcr.io/cloud-builders/gcloud
-    entrypoint: bash
     args:
-      - -c
-      - |
-        gcloud functions call sequence \
-        --data="{\"entriesDir\": \"$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")\", \"origin\": \"${_ORIGIN}\", \"bucket\": \"${_LOG_NAME}\", \"kmsKeyName\": \"ft-log-prod\", \"kmsKeyRing\": \"firmware-release-prod\", \"kmsKeyVersion\": ${_KEY_VERSION}, \"kmsKeyLocation\": \"global\", \"noteKeyName\": \"transparency.dev-aw-ftlog-prod\", \"checkpointCacheControl\": \"${_CHECKPOINT_CACHE}\"}"
+      - functions
+      - call
+      - sequence
+      - --data
+      - >-
+        {
+          "entriesDir": "${_ENTRIES_DIR}",
+          "origin": "${_ORIGIN}",
+          "bucket": "${_LOG_NAME}",
+          "kmsKeyName": "ft-log-prod",
+          "kmsKeyRing": "firmware-release-prod",
+          "kmsKeyVersion": ${_KEY_VERSION},
+          "kmsKeyLocation": "global",
+          "noteKeyName": "transparency.dev-aw-ftlog-prod",
+          "checkpointCacheControl": "${_CHECKPOINT_CACHE}"
+        }
   # Integrate log entry.
   - name: gcr.io/cloud-builders/gcloud
     args:
@@ -130,15 +140,15 @@ steps:
           "noteKeyName": "transparency.dev-aw-ftlog-prod",
           "checkpointCacheControl": "${_CHECKPOINT_CACHE}"
         }
-  # Clean up the file we added to the log bucket now that it's been integrated
-  # to the log.
+  # Clean up the file we added to the _ENTRIES_DIR bucket now that it's been
+  # integrated to the log.
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: bash
     args:
       - -c
       - |
         gcloud storage rm \
-        gs://${_LOG_NAME}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")/trusted_applet_manifest
+        gs://${_LOG_NAME}/${_ENTRIES_DIR}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")
 substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -93,20 +93,25 @@ steps:
       - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${TAG_NAME}/trusted_applet_manifest
   ### Write the firmware release to the transparency log.
   # Copy the log entry to the sequence bucket, preparing to write to log.
+  #
+  # Use the SHA256 of the manifest as the directory to contain the entry that
+  # this trigger instance is trying to add to the log. This allows multiple
+  # triggers to run without colliding.
   - name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
     args:
-      - storage
-      - cp
-      - output/trusted_applet_manifest
-      - gs://${_LOG_NAME}/${_ENTRIES_DIR}/trusted_applet_manifest
+      - -c
+      - |
+        gcloud storage cp output/trusted_applet_manifest \
+        gs://${_LOG_NAME}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")/trusted_applet_manifest
   # Sequence log entry.
   - name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
     args:
-      - functions
-      - call
-      - sequence
-      - --data
-      - '{"entriesDir": "${_ENTRIES_DIR}", "origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}", "kmsKeyName": "ft-log-prod", "kmsKeyRing": "firmware-release-prod", "kmsKeyVersion": ${_KEY_VERSION}, "kmsKeyLocation": "global", "noteKeyName": "transparency.dev-aw-ftlog-prod"}'
+      - -c
+      - |
+        gcloud functions call sequence \
+        --data="{\"entriesDir\": \"$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")\", \"origin\": \"${_ORIGIN}\", \"bucket\": \"${_LOG_NAME}\", \"kmsKeyName\": \"ft-log-prod\", \"kmsKeyRing\": \"firmware-release-prod\", \"kmsKeyVersion\": ${_KEY_VERSION}, \"kmsKeyLocation\": \"global\", \"noteKeyName\": \"transparency.dev-aw-ftlog-prod\"}"
   # Integrate log entry.
   - name: gcr.io/cloud-builders/gcloud
     args:
@@ -115,6 +120,15 @@ steps:
       - integrate
       - --data
       - '{"origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}", "kmsKeyName": "ft-log-prod", "kmsKeyRing": "firmware-release-prod", "kmsKeyVersion": ${_KEY_VERSION}, "kmsKeyLocation": "global", "noteKeyName": "transparency.dev-aw-ftlog-prod"}'
+  # Clean up the file we added to the log bucket now that it's been integrated
+  # to the log.
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        gcloud storage rm \
+        gs://${_LOG_NAME}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")/trusted_applet_manifest
 substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -92,24 +92,34 @@ steps:
   ### Write the firmware release to the transparency log.
   # Copy the log entry to the sequence bucket, preparing to write to log.
   #
-  # Use the SHA256 of the manifest as the directory to contain the entry that
-  # this trigger instance is trying to add to the log. This allows multiple
-  # triggers to run without colliding.
+  # Use the SHA256 of the manifest as the name of the manifest. This allows
+  # multiple triggers to run without colliding.
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: bash
     args:
       - -c
       - |
         gcloud storage cp output/trusted_applet_manifest \
-        gs://${_LOG_NAME}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")/trusted_applet_manifest
+        gs://${_LOG_NAME}/${_ENTRIES_DIR}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")
   # Sequence log entry.
   - name: gcr.io/cloud-builders/gcloud
-    entrypoint: bash
     args:
-      - -c
-      - |
-        gcloud functions call sequence \
-        --data="{\"entriesDir\": \"$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")\", \"origin\": \"${_ORIGIN}\", \"bucket\": \"${_LOG_NAME}\", \"kmsKeyName\": \"ft-log-ci\", \"kmsKeyRing\": \"firmware-release-ci\", \"kmsKeyVersion\": 1, \"kmsKeyLocation\": \"global\", \"noteKeyName\": \"transparency.dev-aw-ftlog-ci\", \"checkpointCacheControl\": \"${_CHECKPOINT_CACHE}\"}"
+      - functions
+      - call
+      - sequence
+      - --data
+      - >-
+        {
+           "entriesDir": "${_ENTRIES_DIR}",
+           "origin": "${_ORIGIN}",
+           "bucket": "${_LOG_NAME}",
+           "kmsKeyName": "ft-log-ci",
+           "kmsKeyRing": "firmware-release-ci",
+           "kmsKeyVersion": ${_KEY_VERSION},
+           "kmsKeyLocation": "global",
+           "noteKeyName": "transparency.dev-aw-ftlog-ci",
+           "checkpointCacheControl": "${_CHECKPOINT_CACHE}"
+         }
   # Integrate log entry.
   - name: gcr.io/cloud-builders/gcloud
     args:
@@ -128,15 +138,15 @@ steps:
           "noteKeyName": "transparency.dev-aw-ftlog-ci",
           "checkpointCacheControl": "${_CHECKPOINT_CACHE}"
         }
-  # Clean up the file we added to the log bucket now that it's been integrated
-  # to the log.
+  # Clean up the file we added to the _ENTRIES_DIR bucket now that it's been
+  # integrated to the log.
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: bash
     args:
       - -c
       - |
         gcloud storage rm \
-        gs://${_LOG_NAME}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")/trusted_applet_manifest
+        gs://${_LOG_NAME}/${_ENTRIES_DIR}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")
 substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware-ci-1

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -91,20 +91,25 @@ steps:
       - output/trusted_applet_manifest
   ### Write the firmware release to the transparency log.
   # Copy the log entry to the sequence bucket, preparing to write to log.
+  #
+  # Use the SHA256 of the manifest as the directory to contain the entry that
+  # this trigger instance is trying to add to the log. This allows multiple
+  # triggers to run without colliding.
   - name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
     args:
-      - storage
-      - cp
-      - output/trusted_applet_manifest
-      - gs://${_LOG_NAME}/${_ENTRIES_DIR}/trusted_applet_manifest
+      - -c
+      - |
+        gcloud storage cp output/trusted_applet_manifest \
+        gs://${_LOG_NAME}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")/trusted_applet_manifest
   # Sequence log entry.
   - name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
     args:
-      - functions
-      - call
-      - sequence
-      - --data
-      - '{"entriesDir": "${_ENTRIES_DIR}", "origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}", "kmsKeyName": "ft-log-ci", "kmsKeyRing": "firmware-release-ci", "kmsKeyVersion": ${_KEY_VERSION}, "kmsKeyLocation": "global", "noteKeyName": "transparency.dev-aw-ftlog-ci"}'
+      - -c
+      - |
+        gcloud functions call sequence \
+        --data="{\"entriesDir\": \"$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")\", \"origin\": \"${_ORIGIN}\", \"bucket\": \"${_LOG_NAME}\", \"kmsKeyName\": \"ft-log-ci\", \"kmsKeyRing\": \"firmware-release-ci\", \"kmsKeyVersion\": 1, \"kmsKeyLocation\": \"global\", \"noteKeyName\": \"transparency.dev-aw-ftlog-ci\"}"
   # Integrate log entry.
   - name: gcr.io/cloud-builders/gcloud
     args:
@@ -112,7 +117,16 @@ steps:
       - call
       - integrate
       - --data
-      - '{"origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}", "kmsKeyName": "ft-log-ci", "kmsKeyRing": "firmware-release-ci", "kmsKeyVersion": ${_KEY_VERSION}, "kmsKeyLocation": "global", "noteKeyName": "transparency.dev-aw-ftlog-ci"}'
+      - '{"origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}", "kmsKeyName": "ft-log-ci", "kmsKeyRing": "firmware-release-ci", "kmsKeyVersion": 1, "kmsKeyLocation": "global", "noteKeyName": "transparency.dev-aw-ftlog-ci"}'
+  # Clean up the file we added to the log bucket now that it's been integrated
+  # to the log.
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        gcloud storage rm \
+        gs://${_LOG_NAME}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")/trusted_applet_manifest
 substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware-ci-1


### PR DESCRIPTION
This fixes the problem that objects uploaded to `entriesDir` are not deleted.