### PR TITLE
Include more info in returned errors during update

### DIFF
--- a/trusted_applet/update.go
+++ b/trusted_applet/update.go
@@ -180,7 +180,7 @@ func readHTTP(ctx context.Context, u *url.URL, timeout time.Duration, logProgres
 	}
 	resp, err := hc.Do(req.WithContext(ctx))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("http.Client.Do(): %v", err)
 	}
 	switch resp.StatusCode {
 	case http.StatusNotFound:
@@ -211,5 +211,5 @@ func readHTTP(ctx context.Context, u *url.URL, timeout time.Duration, logProgres
 		klog.Infof("Downloading %q: finished", u.String())
 	}
 
-	return b, err
+	return b, fmt.Errorf("io.ReadAll(): %v", err)
 }


### PR DESCRIPTION
This makes it clearer whether context timeouts are while trying to make the request, or while downloading the data.
