### PR TITLE
Use same timeout (30s) as set in net.go

### DIFF
--- a/trusted_applet/update.go
+++ b/trusted_applet/update.go
@@ -85,7 +85,7 @@ func updater(ctx context.Context) (*update.Fetcher, *update.Updater, error) {
 
 	updateFetcher, err := update.NewFetcher(ctx,
 		update.FetcherOpts{
-			LogFetcher:     newFetcher(logBaseURL, 10*time.Second, false),
+			LogFetcher:     newFetcher(logBaseURL, 30*time.Second, false),
 			LogOrigin:      updateLogOrigin,
 			LogVerifier:    logVerifier,
 			BinaryFetcher:  binFetcher,
@@ -171,13 +171,10 @@ func readHTTP(ctx context.Context, u *url.URL, timeout time.Duration, logProgres
 	if err != nil {
 		return nil, err
 	}
-	hc := http.DefaultClient
-	if timeout > 0 {
-		// Clone DefaultClient and set a timeout.
-		dc := *hc
-		hc = &dc
-		hc.Timeout = timeout
-	}
+	// Clone DefaultClient and set a timeout.
+	dc := *http.DefaultClient
+	hc := &dc
+	hc.Timeout = timeout
 	resp, err := hc.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("http.Client.Do(): %v", err)


### PR DESCRIPTION
Also removed the pretence of supporting a 0 timeout, this doesn't work because of the context.WithTimeout at the top of the method.
