### PR TITLE
Revert silly error where error would always be returned

### DIFF
--- a/trusted_applet/update.go
+++ b/trusted_applet/update.go
@@ -208,5 +208,5 @@ func readHTTP(ctx context.Context, u *url.URL, timeout time.Duration, logProgres
 		klog.Infof("Downloading %q: finished", u.String())
 	}
 
-	return b, fmt.Errorf("io.ReadAll(): %v", err)
+	return b, nil
 }


### PR DESCRIPTION
This broke the nil error condition. Because all other error returns are decorated, a bare error from this method can be inferred to have come from io.ReadAll
