### PR TITLE
Update binFetcher signature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/machinebox/progress v0.2.0
 	github.com/prometheus/client_golang v1.18.0
 	github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7
-	github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27
+	github.com/transparency-dev/armored-witness-common v0.0.0-20240212125315-835b60b7c617
 	github.com/transparency-dev/armored-witness-os v0.0.0-20240108152453-1d7ba4685285
 	github.com/transparency-dev/formats v0.0.0-20231205184308-949529efd6b3
 	github.com/transparency-dev/merkle v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c766
 github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7/go.mod h1:GTj2zM9nwFe7G7gaXzIbkKJ/PkZfvVq4TdNiA6CBsdo=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27 h1:p8mmHwCvTYbuB52ph9knjwWkQmGNZ+3BZJgsw9xIQq0=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
+github.com/transparency-dev/armored-witness-common v0.0.0-20240212125315-835b60b7c617 h1:GEUXGOHH+Rl6xm6j2QFEkSqiQGOm/95OE86TUBEJAvM=
+github.com/transparency-dev/armored-witness-common v0.0.0-20240212125315-835b60b7c617/go.mod h1:HNfcJnofa9rRIiUjmm3gca9wi3hh38CguvJXoz5ZCL4=
 github.com/transparency-dev/armored-witness-os v0.0.0-20240108152453-1d7ba4685285 h1:0WHJqIUtpM6sM6qSCZqcD11vXSv34fscnn+Z460b9O0=
 github.com/transparency-dev/armored-witness-os v0.0.0-20240108152453-1d7ba4685285/go.mod h1:rOy9R02HninQbXtedtLyDFtuRXu2b08sj0uDt8uc/fY=
 github.com/transparency-dev/formats v0.0.0-20231205184308-949529efd6b3 h1:Mpx9pqc7bKrx2QQxKL3SPbLIGH4gTBR1ZFrNuKq3CcY=

--- a/trusted_applet/update.go
+++ b/trusted_applet/update.go
@@ -74,13 +74,15 @@ func updater(ctx context.Context) (*update.Fetcher, *update.Updater, error) {
 		return nil, nil, fmt.Errorf("binaries URL invalid: %v", err)
 	}
 	bf := newFetcher(binBaseURL, 5*time.Minute, true)
-	binFetcher := func(ctx context.Context, r ftlog.FirmwareRelease) ([]byte, error) {
+	binFetcher := func(ctx context.Context, r ftlog.FirmwareRelease) ([]byte, []byte, error) {
 		p, err := update.BinaryPath(r)
 		if err != nil {
-			return nil, fmt.Errorf("BinaryPath: %v", err)
+			return nil, nil, fmt.Errorf("BinaryPath: %v", err)
 		}
 		klog.Infof("Fetching %v bin from %q", r.Component, p)
-		return bf(ctx, p)
+		// We don't auto-update the bootloader, so no need to fetch HAB signatures.
+		bin, err := bf(ctx, p)
+		return bin, nil, err
 	}
 
 	updateFetcher, err := update.NewFetcher(ctx,


### PR DESCRIPTION
Bumps `common` to `835b60b7c617c69dc26e9b209f59cc1ae2d75a96` and updates the `binFetcher` signature to match the new version.