### PR TITLE
Make the CI witnesses distribute to CI distributor

### DIFF
--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -166,6 +166,6 @@ substitutions:
   _APPLET_PUBLIC_KEY: transparency.dev-aw-applet-ci+3ff32e2c+AV1fgxtByjXuPjPfi0/7qTbEBlPGGCyxqr6ZlppoLOz3
   _OS_PUBLIC_KEY1: transparency.dev-aw-os1-ci+7a0eaef3+AcsqvmrcKIbs21H2Bm2fWb6oFWn/9MmLGNc6NLJty2eQ
   _OS_PUBLIC_KEY2: transparency.dev-aw-os2-ci+af8e4114+AbBJk5MgxRB+68KhGojhUdSt1ts5GAdRIT1Eq9zEkgQh
-  _REST_DISTRIBUTOR_BASE_URL: https://api.transparency.dev
+  _REST_DISTRIBUTOR_BASE_URL: https://api.transparency.dev/distributor-ci
   _BEE: '1'
   _CHECKPOINT_CACHE: 'public, max-age=30'

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -166,6 +166,6 @@ substitutions:
   _APPLET_PUBLIC_KEY: transparency.dev-aw-applet-ci+3ff32e2c+AV1fgxtByjXuPjPfi0/7qTbEBlPGGCyxqr6ZlppoLOz3
   _OS_PUBLIC_KEY1: transparency.dev-aw-os1-ci+7a0eaef3+AcsqvmrcKIbs21H2Bm2fWb6oFWn/9MmLGNc6NLJty2eQ
   _OS_PUBLIC_KEY2: transparency.dev-aw-os2-ci+af8e4114+AbBJk5MgxRB+68KhGojhUdSt1ts5GAdRIT1Eq9zEkgQh
-  _REST_DISTRIBUTOR_BASE_URL: https://api.transparency.dev/distributor-ci
+  _REST_DISTRIBUTOR_BASE_URL: https://api.transparency.dev/ci
   _BEE: '1'
   _CHECKPOINT_CACHE: 'public, max-age=30'


### PR DESCRIPTION
This fixes the current problem, which is that they are trying to distribute to prod. I don't like that the URL will be api.transparency.dev/distributor-ci/distributor/v0/... but deduplicating that will require a lot more work throughout the omniwitness codebase.
