### PR TITLE
Commit to all build envs in manifest

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -57,6 +57,14 @@ steps:
       - --firmware_file=output/trusted_applet.elf
       - --firmware_type=TRUSTED_APPLET
       - --tamago_version=${_TAMAGO_VERSION}
+      - --build_env=FT_LOG_URL=${_LOG_BASE_URL}
+      - --build_env=FT_BIN_URL=${_BIN_BASE_URL}
+      - --build_env=LOG_ORIGIN=${_ORIGIN}
+      - --build_env=LOG_PUBLIC_KEY=${_LOG_PUBLIC_KEY}
+      - --build_env=APPLET_PUBLIC_KEY=${_APPLET_PUBLIC_KEY}
+      - --build_env=OS_PUBLIC_KEY1=${_OS_PUBLIC_KEY1}
+      - --build_env=OS_PUBLIC_KEY2=${_OS_PUBLIC_KEY2}
+      - --build_env=REST_DISTRIBUTOR_BASE_URL=${_REST_DISTRIBUTOR_BASE_URL}
       - --build_env=BEE=${_BEE}
       - --raw
       - --output_file=output/trusted_applet_manifest_unsigned.json

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -18,6 +18,7 @@ steps:
       - |
         docker build \
           --build-arg=TAMAGO_VERSION=${_TAMAGO_VERSION} \
+          --build-arg=GIT_SEMVER_TAG=$(cat /workspace/fake_tag) \
           --build-arg=FT_LOG_URL=${_LOG_BASE_URL} \
           --build-arg=FT_BIN_URL=${_BIN_BASE_URL} \
           --build-arg=LOG_ORIGIN=${_ORIGIN} \
@@ -25,7 +26,6 @@ steps:
           --build-arg=APPLET_PUBLIC_KEY=${_APPLET_PUBLIC_KEY} \
           --build-arg=OS_PUBLIC_KEY1=${_OS_PUBLIC_KEY1} \
           --build-arg=OS_PUBLIC_KEY2=${_OS_PUBLIC_KEY2} \
-          --build-arg=GIT_SEMVER_TAG=$(cat /workspace/fake_tag) \
           --build-arg=REST_DISTRIBUTOR_BASE_URL=${_REST_DISTRIBUTOR_BASE_URL} \
           --build-arg=BEE=${_BEE} \
           -t builder-image \
@@ -72,6 +72,14 @@ steps:
           --firmware_file=output/trusted_applet.elf \
           --firmware_type=TRUSTED_APPLET \
           --tamago_version=${_TAMAGO_VERSION} \
+          --build_env="FT_LOG_URL=${_LOG_BASE_URL}" \
+          --build_env="FT_BIN_URL=${_BIN_BASE_URL}" \
+          --build_env="LOG_ORIGIN=${_ORIGIN}" \
+          --build_env="LOG_PUBLIC_KEY=${_LOG_PUBLIC_KEY}" \
+          --build_env="APPLET_PUBLIC_KEY=${_APPLET_PUBLIC_KEY}" \
+          --build_env="OS_PUBLIC_KEY1=${_OS_PUBLIC_KEY1}" \
+          --build_env="OS_PUBLIC_KEY2=${_OS_PUBLIC_KEY2}" \
+          --build_env="REST_DISTRIBUTOR_BASE_URL=${_REST_DISTRIBUTOR_BASE_URL}" \
           --build_env="BEE=${_BEE}" \
           --raw \
           --output_file=output/trusted_applet_manifest_unsigned.json


### PR DESCRIPTION
Any of these values could be rotated in the future, and given they are critical for reproducible builds they should be in the manifest. One could argue that these should have their own top-level named entry in the manifest rather than being buried in build_envs. For pragmatism, let's use this approach for now and we can revisit this in a month as part of a whole manifest refactor before we commit to v1.
