### PR TITLE
Do not store Cloud Build logs in Cloud Storage.

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -149,6 +149,8 @@ steps:
       - |
         gcloud storage rm \
         gs://${_LOG_NAME}/${_ENTRIES_DIR}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")/trusted_applet_manifest
+options:
+  logging: CLOUD_LOGGING_ONLY
 substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -157,6 +157,8 @@ steps:
       - |
         gcloud storage rm \
         gs://${_LOG_NAME}/${_ENTRIES_DIR}/$(sha256sum output/trusted_applet_manifest | cut -f1 -d" ")/trusted_applet_manifest
+options:
+  logging: CLOUD_LOGGING_ONLY
 substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware-ci-1

--- a/release/cloudbuild_presubmit.yaml
+++ b/release/cloudbuild_presubmit.yaml
@@ -71,6 +71,8 @@ steps:
     args:
       - cat
       - output/trusted_applet_manifest_unsigned.json
+options:
+  logging: CLOUD_LOGGING_ONLY
 substitutions:
   # Build-related.
   _TAMAGO_VERSION: '1.21.5'


### PR DESCRIPTION
Adding a service account to use for a trigger results in this message:

```
Failed to trigger build: generic::invalid_argument: if 'build.service_account' is specified, the build must either (a) specify 'build.logs_bucket', (b) use the REGIONAL_USER_OWNED_BUCKET build.options.default_logs_bucket_behavior option, or (c) use either CLOUD_LOGGING_ONLY / NONE logging options
```

For simplicity, I've chosen to use CLOUD_LOGGING_ONLY instead of having Cloud Build create a new bucket for us, since the logs still get stored in Cloud Logging.