### PR TITLE
Ensure we don't lose trailing part of prefix

### DIFF
--- a/trusted_applet/update.go
+++ b/trusted_applet/update.go
@@ -47,6 +47,9 @@ var (
 // updater returns an updater struct configured from the compiled-in
 // parameters above.
 func updater(ctx context.Context) (*update.Fetcher, *update.Updater, error) {
+	if updateLogURL[len(updateLogURL)-1] != '/' {
+		updateLogURL += "/"
+	}
 	logBaseURL, err := url.Parse(updateLogURL)
 	if err != nil {
 		return nil, nil, fmt.Errorf("firmware log URL invalid: %v", err)
@@ -69,6 +72,9 @@ func updater(ctx context.Context) (*update.Fetcher, *update.Updater, error) {
 		return nil, nil, fmt.Errorf("invalid OS verifier 2: %v", err)
 	}
 
+	if updateBinariesURL[len(updateBinariesURL)-1] != '/' {
+		updateBinariesURL += "/"
+	}
 	binBaseURL, err := url.Parse(updateBinariesURL)
 	if err != nil {
 		return nil, nil, fmt.Errorf("binaries URL invalid: %v", err)


### PR DESCRIPTION
This PR ensures there's always a trailing slash on either of the FT log related URLs.

This fixes a sharp edge, as failing to include the trailing slash in a base URL (e.g. in build-time constants in the applet) will cause the last element in the URL path to silently be dropped.

e.g. https://go.dev/play/p/8jJwNUsmVOz