### PR TITLE
Turn logging verbosity down

### DIFF
--- a/trusted_applet/main.go
+++ b/trusted_applet/main.go
@@ -85,7 +85,6 @@ func init() {
 func main() {
 	klog.InitFlags(nil)
 	flag.Set("vmodule", "journal=1,slots=1,storage=1")
-	flag.Set("v", "1")
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
@@ -273,7 +272,7 @@ func runWithNetworking(ctx context.Context) error {
 						continue
 					}
 				}
-				klog.Info("Scanning for available updates")
+				klog.V(1).Info("Scanning for available updates")
 				if err := updateFetcher.Scan(ctx); err != nil {
 					klog.Errorf("UpdateFetcher.Scan: %v", err)
 					continue


### PR DESCRIPTION
When the device is operating normally we should not be regularly logging frequent operations. This makes it much easier to see the abormal stuff happening. We could consider making the verbosity be a build env so that we can change it easily per environment.
