### PR TITLE
Add CallOnG0 symbol for inspect

### DIFF
--- a/trusted_applet/main.go
+++ b/trusted_applet/main.go
@@ -231,6 +231,10 @@ func main() {
 			klog.Exitf("runWithNetworking: %v", err)
 		}
 	}
+
+	// This forces the linker to keep the symbol present which is necessary for the inspect()
+	// function in the OS to work.
+	runtime.CallOnG0()
 }
 
 // runWithNetworking should only be called when we have an IP network configured.


### PR DESCRIPTION
Force `runtime.CallOnG0` symbol to be present in the symtab so we can invoke it from the OS in the event of a segfault.