### PR TITLE
Allow AW to specify a stable ID and hostname for DHCP

### DIFF
--- a/third_party/dhcp/dhcp.go
+++ b/third_party/dhcp/dhcp.go
@@ -283,6 +283,7 @@ const (
 	//   of 4.
 	optRouter           optionCode = 3
 	optDomainNameServer optionCode = 6
+	optHostname         optionCode = 12
 	optDomainName       optionCode = 15
 	optReqIPAddr        optionCode = 50
 	optLeaseTime        optionCode = 51
@@ -308,7 +309,7 @@ func (code optionCode) lenValid(l int) bool {
 		return l == 1
 	case optRouter, optDomainNameServer:
 		return l%4 == 0
-	case optMessage, optDomainName, optClientID:
+	case optMessage, optDomainName, optClientID, optHostname:
 		return l >= 1
 	case optParamReq:
 		return true // no fixed length

--- a/third_party/dhcp/dhcp_string.go
+++ b/third_party/dhcp/dhcp_string.go
@@ -77,6 +77,7 @@ func _() {
 	_ = x[optSubnetMask-1]
 	_ = x[optRouter-3]
 	_ = x[optDomainNameServer-6]
+	_ = x[optHostname-12]
 	_ = x[optDomainName-15]
 	_ = x[optReqIPAddr-50]
 	_ = x[optLeaseTime-51]
@@ -98,6 +99,7 @@ const (
 	_optionCode_name_5 = "optDHCPMsgTypeoptDHCPServeroptParamReqoptMessage"
 	_optionCode_name_6 = "optRenewalTimeoptRebindingTime"
 	_optionCode_name_7 = "optClientID"
+	_optionCode_name_8 = "optHostname"
 )
 
 var (
@@ -127,6 +129,8 @@ func (i optionCode) String() string {
 		return _optionCode_name_6[_optionCode_index_6[i]:_optionCode_index_6[i+1]]
 	case i == 61:
 		return _optionCode_name_7
+	case i == 12:
+		return _optionCode_name_8
 	default:
 		return "optionCode(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/trusted_applet/net.go
+++ b/trusted_applet/net.go
@@ -102,7 +102,7 @@ func init() {
 // ensure that networking clients/services are only run while a leased IP is held.
 //
 // This function blocks until the passed-in ctx is Done.
-func runDHCP(ctx context.Context, nicID tcpip.NICID, f func(context.Context) error) {
+func runDHCP(ctx context.Context, nicID tcpip.NICID, clientID string, hostname string, f func(context.Context) error) {
 	// This context tracks the lifetime of the IP lease we get (if any) from the DHCP server.
 	// We'll only know what that lease is once we acquire the new IP, which happens inside
 	// the aquired func below.
@@ -185,7 +185,7 @@ func runDHCP(ctx context.Context, nicID tcpip.NICID, f func(context.Context) err
 	}
 
 	// Start the DHCP client.
-	c := dhcp.NewClient(iface.Stack, nicID, iface.Link.LinkAddress(), 30*time.Second, time.Second, time.Second, acquired)
+	c := dhcp.NewClient(iface.Stack, nicID, iface.Link.LinkAddress(), clientID, hostname, 30*time.Second, time.Second, time.Second, acquired)
 	klog.Info("Starting DHCPClient...")
 	c.Run(ctx)
 }


### PR DESCRIPTION
This PR improves quality of life for folks running a witness on their network a bit.

With this change, the AW:
- sends a stable `ClientID` (`AW-<serial>`) to the DHCP server, allowing the server to be configured with a specific set of values to return (you can generally do the same with MAC addresses, but this is a bit friendlier),
- sends a requested `hostname` (a sanitised version of the witness identity name, e.g. `dev-armoredwitness-proud-meadow`)

