### PR TITLE
avoid applet exit on static networking restart

### DIFF
--- a/trusted_applet/main.go
+++ b/trusted_applet/main.go
@@ -242,7 +242,7 @@ func main() {
 	} else {
 		for {
 			if err := runWithNetworking(ctx); err != nil && err != context.Canceled {
-				klog.Exitf("runWithNetworking: %v", err)
+				klog.Warningf("runWithNetworking: %v", err)
 			}
 		}
 	}

--- a/trusted_applet/main.go
+++ b/trusted_applet/main.go
@@ -240,8 +240,10 @@ func main() {
 		}
 		runDHCP(ctx, nicID, fmt.Sprintf("AW-%s", status.Serial), hostname, runWithNetworking)
 	} else {
-		if err := runWithNetworking(ctx); err != nil && err != context.Canceled {
-			klog.Exitf("runWithNetworking: %v", err)
+		for {
+			if err := runWithNetworking(ctx); err != nil && err != context.Canceled {
+				klog.Exitf("runWithNetworking: %v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
On large NTP changes the applet aborts with static networking, this prevents that.