### PR TITLE
Derive BastionID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.19.1
 	github.com/transparency-dev/armored-witness-boot v0.1.0
 	github.com/transparency-dev/armored-witness-common v0.0.0-20240313170947-0b19d0fb8b95
-	github.com/transparency-dev/armored-witness-os v0.1.2
+	github.com/transparency-dev/armored-witness-os v0.1.3-0.20240524123036-bdd4b0b96386
 	github.com/transparency-dev/formats v0.0.0-20231205184308-949529efd6b3
 	github.com/transparency-dev/serverless-log v0.0.0-20231215122707-66f68a7705f5
 	github.com/transparency-dev/witness v0.0.0-20240311170858-5de1177dc362

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/transparency-dev/armored-witness-common v0.0.0-20240313170947-0b19d0f
 github.com/transparency-dev/armored-witness-common v0.0.0-20240313170947-0b19d0fb8b95/go.mod h1:cb6aKsLVU2OUk8+UjD8xvzxU84miHXLMHJaxO2gHDus=
 github.com/transparency-dev/armored-witness-os v0.1.2 h1:t8IrQQ9n0+lqvhASGfc9NOuEH3bykPSjtcMbWnARMZE=
 github.com/transparency-dev/armored-witness-os v0.1.2/go.mod h1:Yt2PelPhnZ5Vc+/XJRPHoFaV5gTBw9xBXcMQJZTwSVM=
+github.com/transparency-dev/armored-witness-os v0.1.3-0.20240524123036-bdd4b0b96386 h1:WHmJqV1L7dqAR5WXhOpFDL5jo4Rp2gCzvtmDh5FcX7E=
+github.com/transparency-dev/armored-witness-os v0.1.3-0.20240524123036-bdd4b0b96386/go.mod h1:N+hTvqWTb08EeJC+DLEIPvnG4uI9ibnJVIA+oZaOBn4=
 github.com/transparency-dev/formats v0.0.0-20231205184308-949529efd6b3 h1:Mpx9pqc7bKrx2QQxKL3SPbLIGH4gTBR1ZFrNuKq3CcY=
 github.com/transparency-dev/formats v0.0.0-20231205184308-949529efd6b3/go.mod h1:tY9Z9oBaYdQt4NWIhsFAtv0altwLk+K9Gg/2tbS0eBQ=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,6 @@ github.com/transparency-dev/armored-witness-boot v0.1.0 h1:OBlz71PCmPju9cDI1VEmy
 github.com/transparency-dev/armored-witness-boot v0.1.0/go.mod h1:XpiSLWNiDplWVYjtR1FY/wyFqiWK++5pLCiYe3PZZC8=
 github.com/transparency-dev/armored-witness-common v0.0.0-20240313170947-0b19d0fb8b95 h1:qOh9vp/TLfJ1X46bk756se0wdlKHSV2TrGUMa3kz91w=
 github.com/transparency-dev/armored-witness-common v0.0.0-20240313170947-0b19d0fb8b95/go.mod h1:cb6aKsLVU2OUk8+UjD8xvzxU84miHXLMHJaxO2gHDus=
-github.com/transparency-dev/armored-witness-os v0.1.2 h1:t8IrQQ9n0+lqvhASGfc9NOuEH3bykPSjtcMbWnARMZE=
-github.com/transparency-dev/armored-witness-os v0.1.2/go.mod h1:Yt2PelPhnZ5Vc+/XJRPHoFaV5gTBw9xBXcMQJZTwSVM=
 github.com/transparency-dev/armored-witness-os v0.1.3-0.20240524123036-bdd4b0b96386 h1:WHmJqV1L7dqAR5WXhOpFDL5jo4Rp2gCzvtmDh5FcX7E=
 github.com/transparency-dev/armored-witness-os v0.1.3-0.20240524123036-bdd4b0b96386/go.mod h1:N+hTvqWTb08EeJC+DLEIPvnG4uI9ibnJVIA+oZaOBn4=
 github.com/transparency-dev/formats v0.0.0-20231205184308-949529efd6b3 h1:Mpx9pqc7bKrx2QQxKL3SPbLIGH4gTBR1ZFrNuKq3CcY=

--- a/trusted_applet/key.go
+++ b/trusted_applet/key.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"crypto/aes"
+	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
@@ -135,6 +136,19 @@ func deriveNoteSigner(diversifier string, uniqueID string, keyName func(io.Reade
 		log.Fatalf("Failed to generate derived note key: %v", err)
 	}
 	return sec, pub
+}
+
+// deriveEd25519 uses the hardware secret to device a new ed25519 keypair.
+//
+// diversifier should uniquely specify the key's intended usage, uniqueID should be the
+// device's h/w unique identifier.
+func deriveEd25519(diversifier string, uniqueID string) (ed25519.PrivateKey, ed25519.PublicKey) {
+	r := deriveHKDF(diversifier, uniqueID)
+	pub, priv, err := ed25519.GenerateKey(r)
+	if err != nil {
+		log.Fatalf("Failed to generate derived ed25519 key: %v", err)
+	}
+	return priv, pub
 }
 
 // randomName generates a random human-friendly name.

--- a/trusted_applet/main.go
+++ b/trusted_applet/main.go
@@ -184,6 +184,7 @@ func main() {
 		Identity:          witnessPublicKey,
 		IDAttestPublicKey: attestPublicKey,
 		AttestedID:        witnessPublicKeyAttestation,
+		AttestedBastionID: bastionIDAttestation,
 	}, nil)
 
 	klog.Infof("Attestation key:\n%s", attestPublicKey)
@@ -281,6 +282,7 @@ func runWithNetworking(ctx context.Context) error {
 		Identity:          witnessPublicKey,
 		IDAttestPublicKey: attestPublicKey,
 		AttestedID:        witnessPublicKeyAttestation,
+		AttestedBastionID: bastionIDAttestation,
 		IP:                addr.Address.String(),
 	}, nil)
 


### PR DESCRIPTION
This PR derives a new key to be used to authenticate the witness to a Bastion host.

I've done some refactoring to simplify/reuse code where possible to avoid mistakes in the future.

Key derivation results remain the same with the refactoring:

Before 
```
----------------------------------------------------------- Trusted OS ----
Serial number ..............: 720A9DEAD4391E1E
Secure Boot ................: false
SRK hash ...................:
Revision ...................: a2c259b
Version ....................: 0.1.2-11-ga2c259b
Runtime ....................: go1.22.0 tamago/arm
Link .......................: false
MAC ........................: c6:08:a0:62:04:44
IdentityCounter ............: 0
Witness/Identity ...........: DEV:ArmoredWitness-misty-snow+4235d37b+ATQcX3zXpdLJdudAP97VhTkO4m0DEyld9ndttS/XdIKq
Witness/IP .................:
Witness/AttestationKey .....: DEV:AW-ID-Attestation-720A9DEAD4391E1E+ca59d820+AZhTXIbOHFbhQrHf22YK+4lLMsCfBrzA3zdA3IP5PaZh
```

After
```
----------------------------------------------------------- Trusted OS ----
Serial number ..............: 720A9DEAD4391E1E
Secure Boot ................: false
SRK hash ...................:
Revision ...................: ee18b13
Version ....................: 0.1.2-17-gee18b13
Runtime ....................: go1.22.0 tamago/arm
Link .......................: false
MAC ........................: c6:08:a0:62:04:44
IdentityCounter ............: 0
Witness/Identity ...........: DEV:ArmoredWitness-misty-snow+4235d37b+ATQcX3zXpdLJdudAP97VhTkO4m0DEyld9ndttS/XdIKq
Witness/IP .................:
Witness/AttestationKey .....: DEV:AW-ID-Attestation-720A9DEAD4391E1E+ca59d820+AZhTXIbOHFbhQrHf22YK+4lLMsCfBrzA3zdA3IP5PaZh
Witness/AttestedIdentity ...: [below]

ArmoredWitness ID attestation v1
720A9DEAD4391E1E
0
DEV:ArmoredWitness-misty-snow+4235d37b+ATQcX3zXpdLJdudAP97VhTkO4m0DEyld9ndttS/XdIKq

— DEV:AW-ID-Attestation-720A9DEAD4391E1E ylnYIEjwPNzNhE6A6Mx/4zhes5Wxg+45gcCO9atyhu6bucDCrf/99BPSO4SQwdDxHAdPRod53cicvfgCXskTMMv/CgI=

Witness/AttestedBastionID ..: [below]

ArmoredWitness BastionID attestation v1
720A9DEAD4391E1E
0
3a8a5615f38f0e3388d389d031353a6041acd12b30b38d5b6ddcaf16fd01dcc1

— DEV:AW-ID-Attestation-720A9DEAD4391E1E ylnYIC9IFCP5AKb34hlD9PWAUogTA6cIV+7z5OMr7LNfLMZpKUnlclQ25wPl4ka7giIxOQ4WxcsfKw+eeImN5b3f9AQ=

----------------------------------------------------------- Trusted OS ----
```

Towards transparency-dev/armored-witness/issues/253
