### PR TITLE
Add status HTTP endpoint

### DIFF
--- a/trusted_applet/main.go
+++ b/trusted_applet/main.go
@@ -328,6 +328,17 @@ func runWithNetworking(ctx context.Context) error {
 			w.Header().Add("Content-Type", "text/plain")
 			w.Write([]byte("ok, check /consolelog!"))
 		})
+		srvMux.HandleFunc("/status", func(w http.ResponseWriter, _ *http.Request) {
+			var s api.Status
+			if err := syscall.Call("RPC.Status", nil, &s); err != nil {
+				w.Header().Add("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(err.Error()))
+				return
+			}
+			w.Header().Add("Content-Type", "text/plain")
+			w.Write([]byte(s.Print()))
+		})
 		srv := &http.Server{
 			ReadTimeout:  5 * time.Second,
 			WriteTimeout: 10 * time.Second,


### PR DESCRIPTION
This PR adds a local admin `/status` HTTP endpoint to make it a little easier for custodians to fetch this info from running devices.

```bash
$ curl -i http://10.0.0.1:8081/status
HTTP/1.1 200 OK
Content-Type: text/plain
Date: Wed, 12 Jun 2024 18:06:41 GMT
Content-Length: 1408

----------------------------------------------------------- Trusted OS ----
Serial number ..............: 720A9DEAD4391E1E
Secure Boot ................: false
SRK hash ...................:
Revision ...................: d8827e6
Version ....................: 0.1.2-21-gd8827e6
Runtime ....................: go1.22.0 tamago/arm
Link .......................: true
MAC ........................: c6:08:a0:62:04:44
IdentityCounter ............: 0
Witness/Identity ...........: DEV:ArmoredWitness-misty-snow+4235d37b+ATQcX3zXpdLJdudAP97VhTkO4m0DEyld9ndttS/XdIKq
Witness/IP .................: 10.0.0.1
Witness/AttestationKey .....: DEV:AW-ID-Attestation-720A9DEAD4391E1E+ca59d820+AZhTXIbOHFbhQrHf22YK+4lLMsCfBrzA3zdA3IP5PaZh
Witness/AttestedIdentity ...: [below]

ArmoredWitness ID attestation v1
720A9DEAD4391E1E
0
DEV:ArmoredWitness-misty-snow+4235d37b+ATQcX3zXpdLJdudAP97VhTkO4m0DEyld9ndttS/XdIKq

— DEV:AW-ID-Attestation-720A9DEAD4391E1E ylnYIEjwPNzNhE6A6Mx/4zhes5Wxg+45gcCO9atyhu6bucDCrf/99BPSO4SQwdDxHAdPRod53cicvfgCXskTMMv/CgI=

Witness/AttestedBastionID ..: [below]

ArmoredWitness BastionID attestation v1
720A9DEAD4391E1E
0
3a8a5615f38f0e3388d389d031353a6041acd12b30b38d5b6ddcaf16fd01dcc1

— DEV:AW-ID-Attestation-720A9DEAD4391E1E ylnYIC9IFCP5AKb34hlD9PWAUogTA6cIV+7z5OMr7LNfLMZpKUnlclQ25wPl4ka7giIxOQ4WxcsfKw+eeImN5b3f9AQ=

----------------------------------------------------------- Trusted OS ---
```