### PR TITLE
Bump Tamago to 1.22.4

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   build:
     env:
-      TAMAGO_VERSION: 1.22.0
+      TAMAGO_VERSION: 1.22.4
       TAMAGO: /usr/local/tamago-go/bin/go
       APPLET_PRIVATE_KEY: /tmp/applet.sec
       APPLET_PUBLIC_KEY: /tmp/applet.pub

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ REST_DISTRIBUTOR_BASE_URL ?= https://api.transparency.dev
 BASTION_ADDR ?= 
 
 TAMAGO_SEMVER = $(shell [ -n "${TAMAGO}" -a -x "${TAMAGO}" ] && ${TAMAGO} version | sed 's/.*go\([0-9]\.[0-9]*\.[0-9]*\).*/\1/')
-MINIMUM_TAMAGO_VERSION=1.22.0
+MINIMUM_TAMAGO_VERSION=1.22.4
 
 SHELL = /bin/bash
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transparency-dev/armored-witness-applet
 
-go 1.22.0
+go 1.22.4
 
 require (
 	github.com/beevik/ntp v1.4.3


### PR DESCRIPTION
This PR bumps the minimum Tamago version to 1.22.4, in line with transparency-dev/armored-witness-os#259.

Needs transparency-dev/armored-witness#264 for presubmit.