### PR TITLE
Bump go and tamago to latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ REST_DISTRIBUTOR_BASE_URL ?= https://api.transparency.dev
 BASTION_ADDR ?= 
 
 TAMAGO_SEMVER = $(shell [ -n "${TAMAGO}" -a -x "${TAMAGO}" ] && ${TAMAGO} version | sed 's/.*go\([0-9]\.[0-9]*\.[0-9]*\).*/\1/')
-MINIMUM_TAMAGO_VERSION=1.22.4
+MINIMUM_TAMAGO_VERSION=1.22.6
 
 SHELL = /bin/bash
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transparency-dev/armored-witness-applet
 
-go 1.22.4
+go 1.22.6
 
 require (
 	github.com/beevik/ntp v1.4.3


### PR DESCRIPTION
Started on this journey because https://github.com/transparency-dev/armored-witness-common/pull/36 failed due to old version. May as well bring everything up to the latest version of tamago.
