### PR TITLE
Bump witness to 2141e0e43f896d5ec9af9f6312b660ea343c330d

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/transparency-dev/armored-witness-os v0.3.1
 	github.com/transparency-dev/formats v0.0.0-20241003145927-a04dcc2a37e4
 	github.com/transparency-dev/serverless-log v0.0.0-20240408141044-5d483a81bdb7
-	github.com/transparency-dev/witness v0.0.0-20250113194647-353e718338ce
+	github.com/transparency-dev/witness v0.0.0-20250203104351-2141e0e43f89
 	github.com/usbarmory/GoTEE v0.0.0-20240913144333-7e62563c0628
 	github.com/usbarmory/imx-enet v0.0.0-20240304151238-5b3010d57ea3
 	github.com/usbarmory/tamago v0.0.0-20240924114619-273d67cd811d
@@ -47,7 +47,7 @@ require (
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/transparency-dev/merkle v0.0.3-0.20240919113952-3c979d16ee14 // indirect
 	github.com/transparency-dev/trillian-tessera v0.1.0 // indirect
-	golang.org/x/net v0.33.0 // indirect
+	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/transparency-dev/trillian-tessera v0.1.0 h1:2ZzpsBH3U2JWQ4pcUG11dYXwH
 github.com/transparency-dev/trillian-tessera v0.1.0/go.mod h1:cpk4hVzA5aXcaP6r5UD3EJBQWauI0hprgn27xF5a3ls=
 github.com/transparency-dev/witness v0.0.0-20250113194647-353e718338ce h1:OVVz5Pu0Ap8sxMv/PU6jEeI2ePocNs7pSmh5/iZL7hA=
 github.com/transparency-dev/witness v0.0.0-20250113194647-353e718338ce/go.mod h1:f8uryvf4oIca8u+hp0SefEUCfModMybz+ZBCnOBUgSI=
+github.com/transparency-dev/witness v0.0.0-20250203104351-2141e0e43f89 h1:ElnFS3ALjEloOjeZb0mPgEmhxrxVKrmLT+gsqInBgZw=
+github.com/transparency-dev/witness v0.0.0-20250203104351-2141e0e43f89/go.mod h1:shAwBt3melT2MQc02Fn+suoUxjL3Mb4YxeUbAAyXWwM=
 github.com/usbarmory/GoTEE v0.0.0-20240913144333-7e62563c0628 h1:PGlLJYe1YMmzmSYXhEkOSXSrQjV/mXk6CNk5LTgnndM=
 github.com/usbarmory/GoTEE v0.0.0-20240913144333-7e62563c0628/go.mod h1:solbXmDpRv6u6CmfHiFi3rwsYoTlZXToith669WnvgM=
 github.com/usbarmory/imx-enet v0.0.0-20240304151238-5b3010d57ea3 h1:o6ixndtlZMRKOXcDCc2Mw6lSu1f79jmIaSY0wyzkmq4=
@@ -97,6 +99,7 @@ golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
 golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,6 @@ github.com/transparency-dev/serverless-log v0.0.0-20240408141044-5d483a81bdb7 h1
 github.com/transparency-dev/serverless-log v0.0.0-20240408141044-5d483a81bdb7/go.mod h1:A+cQ9EQeah/Ua7JaMOAAKkCfyDZPsq74o+UgwqQEPsQ=
 github.com/transparency-dev/trillian-tessera v0.1.0 h1:2ZzpsBH3U2JWQ4pcUG11dYXwH97vtSav1ZQtFTMI9So=
 github.com/transparency-dev/trillian-tessera v0.1.0/go.mod h1:cpk4hVzA5aXcaP6r5UD3EJBQWauI0hprgn27xF5a3ls=
-github.com/transparency-dev/witness v0.0.0-20250113194647-353e718338ce h1:OVVz5Pu0Ap8sxMv/PU6jEeI2ePocNs7pSmh5/iZL7hA=
-github.com/transparency-dev/witness v0.0.0-20250113194647-353e718338ce/go.mod h1:f8uryvf4oIca8u+hp0SefEUCfModMybz+ZBCnOBUgSI=
 github.com/transparency-dev/witness v0.0.0-20250203104351-2141e0e43f89 h1:ElnFS3ALjEloOjeZb0mPgEmhxrxVKrmLT+gsqInBgZw=
 github.com/transparency-dev/witness v0.0.0-20250203104351-2141e0e43f89/go.mod h1:shAwBt3melT2MQc02Fn+suoUxjL3Mb4YxeUbAAyXWwM=
 github.com/usbarmory/GoTEE v0.0.0-20240913144333-7e62563c0628 h1:PGlLJYe1YMmzmSYXhEkOSXSrQjV/mXk6CNk5LTgnndM=
@@ -97,8 +95,7 @@ golang.org/x/crypto/x509roots/fallback v0.0.0-20230623170555-183630ada7e0 h1:8O7
 golang.org/x/crypto/x509roots/fallback v0.0.0-20230623170555-183630ada7e0/go.mod h1:kNa9WdvYnzFwC79zRpLRMJbdEFlhyM5RPFBBZp/wWH8=
 golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
 golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
-golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
-golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
 golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=


### PR DESCRIPTION
This PR bumps the `transparency-dev/witness` dep to `2141e0e43f896d5ec9af9f6312b660ea343c330d
` in order to pull in transparency-dev/witness#325 which fixes issues with [C2SP tlog-witness](https://c2sp.org/tlog-witness) spec compliance.