### PR TITLE
remove soon-to-be-deleted email addresses

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,3 @@
 Google LLC
-Andrea Barisani <andrea.barisani@withsecure.com> <andrea@inversepath.com>
-Andrej Rosano <andrej.rosano@withsecure.com> <andrej@inversepath.com>
+Andrea Barisani <andrea@inversepath.com>
+Andrej Rosano <andrej@inversepath.com>


### PR DESCRIPTION
This PR removes email addresses which are going to be disabled shortly after Q2 2025.