### PR TITLE
Bump Tamago-go to  1.24.3

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   build:
     env:
-      TAMAGO_VERSION: 1.24.1
+      TAMAGO_VERSION: 1.24.3
       TAMAGO: /usr/local/tamago-go/bin/go
       APPLET_PRIVATE_KEY: /tmp/applet.sec
       APPLET_PUBLIC_KEY: /tmp/applet.pub

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ REST_DISTRIBUTOR_BASE_URL ?= https://api.transparency.dev
 BASTION_ADDR ?= 
 
 TAMAGO_SEMVER = $(shell [ -n "${TAMAGO}" -a -x "${TAMAGO}" ] && ${TAMAGO} version | sed 's/.*go\([0-9]\.[0-9]*\.[0-9]*\).*/\1/')
-MINIMUM_TAMAGO_VERSION=1.24.1
+MINIMUM_TAMAGO_VERSION=1.24.3
 
 SHELL = /usr/bin/env bash
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transparency-dev/armored-witness-applet
 
-go 1.24.1
+go 1.24.3
 
 require (
 	github.com/beevik/ntp v1.4.3
@@ -15,9 +15,9 @@ require (
 	github.com/transparency-dev/formats v0.0.0-20250421220931-bb8ad4d07c26
 	github.com/transparency-dev/serverless-log v0.0.0-20250425165558-64e1d2007a10
 	github.com/transparency-dev/witness v0.0.0-20250513132309-561ef3c9fe9e
-	github.com/usbarmory/GoTEE v0.0.0-20240913144333-7e62563c0628
+	github.com/usbarmory/GoTEE v0.0.0-20250318141819-064601644998
 	github.com/usbarmory/imx-enet v0.0.0-20240304151238-5b3010d57ea3
-	github.com/usbarmory/tamago v0.0.0-20250327164348-77f2a17385b6
+	github.com/usbarmory/tamago v0.0.0-20250507084546-5652946876c4
 	go.mercari.io/go-dnscache v0.3.0
 	golang.org/x/crypto v0.38.0
 	golang.org/x/crypto/x509roots/fallback v0.0.0-20230623170555-183630ada7e0

--- a/go.sum
+++ b/go.sum
@@ -84,13 +84,13 @@ github.com/transparency-dev/trillian-tessera v0.1.3-0.20250428160849-0993bb6daf5
 github.com/transparency-dev/trillian-tessera v0.1.3-0.20250428160849-0993bb6daf5b/go.mod h1:jARcxCIWevuPy8XsxN7Q8waDV+M4rY9fNKIXJXBbzXo=
 github.com/transparency-dev/witness v0.0.0-20250513132309-561ef3c9fe9e h1:B4/NZhcUELWU/vbVy11iLsP2X78vAnIhMjNxFqkjPJQ=
 github.com/transparency-dev/witness v0.0.0-20250513132309-561ef3c9fe9e/go.mod h1:8DGzKZpQjHoZxJdd+9cfL6dGQl2Vv5i1bHjVJZex69g=
-github.com/usbarmory/GoTEE v0.0.0-20240913144333-7e62563c0628 h1:PGlLJYe1YMmzmSYXhEkOSXSrQjV/mXk6CNk5LTgnndM=
-github.com/usbarmory/GoTEE v0.0.0-20240913144333-7e62563c0628/go.mod h1:solbXmDpRv6u6CmfHiFi3rwsYoTlZXToith669WnvgM=
+github.com/usbarmory/GoTEE v0.0.0-20250318141819-064601644998 h1:q9SRKEBHh511fqjCh61Rhbc/E4ooscNjvd+cjxrwwYw=
+github.com/usbarmory/GoTEE v0.0.0-20250318141819-064601644998/go.mod h1:uEfj6hLaVWKoi1ZAUtiMsJKUBUj65E5U5K/QxZi2hz8=
 github.com/usbarmory/imx-enet v0.0.0-20240304151238-5b3010d57ea3 h1:o6ixndtlZMRKOXcDCc2Mw6lSu1f79jmIaSY0wyzkmq4=
 github.com/usbarmory/imx-enet v0.0.0-20240304151238-5b3010d57ea3/go.mod h1:oQC2UR2fup7IJPcIWMjOUIcGUEPhcftL4sTOcmrH63s=
 github.com/usbarmory/tamago v0.0.0-20220823080407-04f05cf2a5a3/go.mod h1:Lok79mjbJnhoBGqhX5cCUsZtSemsQF5FNZW+2R1dRr8=
-github.com/usbarmory/tamago v0.0.0-20250327164348-77f2a17385b6 h1:bUPSnUv06M5Ds+iq3MRD+pgQOjozfX3wzEzkzxpeUgo=
-github.com/usbarmory/tamago v0.0.0-20250327164348-77f2a17385b6/go.mod h1:NL88q9ZsIPYFzXaosAeKgu1Kr5i1k4Rau3wnbNBL5bY=
+github.com/usbarmory/tamago v0.0.0-20250507084546-5652946876c4 h1:v7E+9bzBJPfup/R5hmdw7jwTWzk58SlvI6u400UC9qg=
+github.com/usbarmory/tamago v0.0.0-20250507084546-5652946876c4/go.mod h1:BtIwki3LlSlQJ/sW1wL2unqgYndZsSDioeyI3bVtZO8=
 go.mercari.io/go-dnscache v0.3.0 h1:x5CLQvIHHPm7uq1A3ihAHAyynpUnEpHmj+sfbPjK7ec=
 go.mercari.io/go-dnscache v0.3.0/go.mod h1:k+iiZhIW/8Lykwr05O5Xms5tOfo42Rz8Hwnts1JUYNE=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=


### PR DESCRIPTION
This PR bumps tamago-go to `1.24.3`, and updates the `tamago` and `GoTEE` deps to the same versions as in transparency-dev/armored-witness-os#files.

TODO: Needs transparency-dev/armored-witness#366 merged and applied first.